### PR TITLE
increase memory

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -256,7 +256,7 @@
     "dockerImage": "${artifactId}:${version}",
     "dockerArgs": {
       "HostConfig": {
-        "Memory": 357913941,
+        "Memory": 715827882,
         "PortBindings": {
           "8081/tcp": [
             {


### PR DESCRIPTION
Getting an error on the reference environments:

```
13:55:02.716 [vert.x-worker-thread-0] ERROR LiquibaseUtil        [10822eqId] Error while initializing schema for the module
liquibase.exception.ChangeLogParseException: liquibase.exception.SetupException: Out of memory
```
clears up if I manually increase memory, this change is to update the defaults.