### PR TITLE
Added java_options param to create a heap dump on OOM error

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -298,7 +298,7 @@
     "env": [
       {
         "name": "JAVA_OPTIONS",
-        "value": "-XX:MaxRAMPercentage=66.0"
+        "value": "-XX:MaxRAMPercentage=66.0 -XX:+HeapDumpOnOutOfMemoryError"
       },
       {
         "name": "DB_HOST",


### PR DESCRIPTION
-XX:+HeapDumpOnOutOfMemoryError param ensures that a heap dump file is recorded when module crashes with OOM. It should allow us to get a heap dump from the env when it happens and quickly understand what's consuming all the memory.