### PR TITLE
[MODPUBSUB-96] Add permission to send events to mod-patron-blocks

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 ## 2020-04-20 v.1.2.0-SNAPSHOT
 * [MODPUBSUB-82](https://issues.folio.org/browse/MODPUBSUB-82) Switch Liquibase integration to use [folio-liquibase-util](https://github.com/folio-org/folio-liquibase-util)
+* [MODPUBSUB-96](https://issues.folio.org/browse/MODPUBSUB-96) Add permission to send events to mod-patron-blocks
 
 ## 2020-04-27 v1.1.5
 * [MODPUBSUB-83](https://issues.folio.org/browse/MODPUBSUB-83) Add env variable to set replication factor and number of partitions for topics in kafka

--- a/README.md
+++ b/README.md
@@ -537,7 +537,7 @@ As a result, we can send an event from the publisher module to "mod-pubsub" and 
 #### Permissions
 ##### "mod-pubsub" permissions workflow:
 At first "mod-pubsub" checks whether "pub-sub" user exists in the system. If user exists, then:
-- adds persmissions from the file "pubsub-user-permissions.csv" for the "pub-sub" user.
+- adds permissions from the file "pubsub-user-permissions.csv" for the "pub-sub" user.
 
  ##### Otherwise:
  If user does not exist in the system, then:

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -283,6 +283,11 @@
       "permissionName": "circulation.events.post",
       "displayName": "Circulation - post event",
       "description": "Post event to circulation"
+    },
+    {
+      "permissionName": "patron-blocks.events.post",
+      "displayName": "Patron blocks - post event",
+      "description": "Post events to patron blocks"
     }
   ],
   "launchDescriptor": {

--- a/mod-pubsub-server/src/main/resources/permissions/pubsub-user-permissions.csv
+++ b/mod-pubsub-server/src/main/resources/permissions/pubsub-user-permissions.csv
@@ -2,3 +2,4 @@ source-storage.events.post
 source-records-manager.events.post
 inventory.events.post
 circulation.events.post
+patron-blocks.events.post


### PR DESCRIPTION
In order to enable delivery of events implemented in scope of [CIRC-734](https://issues.folio.org/browse/CIRC-734) and [MODFEE-53](https://issues.folio.org/browse/MODFEE-53) to mod-patron-blocks, mod-pubsub must be granted a new pemission:
```
{
      "permissionName": "patron-blocks.events.post",
      "displayName": "Patron blocks - post event",
      "description": "Post events to patron blocks"
}
```

Resolves [MODPUBSUB-96](https://issues.folio.org/browse/MODPUBSUB-96)

