### PR TITLE
Update folio-liquibase-util dependency to v1.0.0

### DIFF
--- a/mod-pubsub-server/pom.xml
+++ b/mod-pubsub-server/pom.xml
@@ -73,7 +73,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>folio-liquibase-util</artifactId>
-      <version>0.0.1-SNAPSHOT</version>
+      <version>1.0.0</version>
       <type>jar</type>
     </dependency>
     <dependency>


### PR DESCRIPTION
folio-liquibase-util v1.0.0 was released, its new development version is 1.1.0-SNAPSHOT, therefore v0.0.1-SNAPSHOT will no longer be available