### PR TITLE
MODPUBSUB-107: Set/update lastName for the pub-sub user.

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -185,6 +185,7 @@
           "modulePermissions": [
             "users.collection.get",
             "users.item.post",
+            "users.item.put",
             "login.item.post",
             "perms.users.item.post"
           ]

--- a/mod-pubsub-server/src/main/java/org/folio/representation/User.java
+++ b/mod-pubsub-server/src/main/java/org/folio/representation/User.java
@@ -1,0 +1,82 @@
+package org.folio.representation;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+
+public class User {
+  private String id;
+  private String username;
+  private boolean active;
+  private Personal personal;
+  // Everything else that we're not expecting, just in case
+  private final Map<String, Object> unmapped = new HashMap<>();
+
+  public String getId() {
+    return id;
+  }
+
+  public void setId(String id) {
+    this.id = id;
+  }
+
+  public String getUsername() {
+    return username;
+  }
+
+  public void setUsername(String username) {
+    this.username = username;
+  }
+
+  public boolean isActive() {
+    return active;
+  }
+
+  public void setActive(boolean active) {
+    this.active = active;
+  }
+
+  public Personal getPersonal() {
+    return personal;
+  }
+
+  public void setPersonal(Personal personal) {
+    this.personal = personal;
+  }
+
+  @JsonAnySetter
+  public void handleUnmapped(String key, Object value) {
+    unmapped.put(key, value);
+  }
+
+  @JsonAnyGetter
+  public Map<String, Object> getUnmapped() {
+    return unmapped;
+  }
+
+  public static class Personal {
+    private String lastName;
+
+    private final Map<String, Object> unmapped = new HashMap<>();
+
+    public String getLastName() {
+      return lastName;
+    }
+
+    public void setLastName(String lastName) {
+      this.lastName = lastName;
+    }
+
+    @JsonAnySetter
+    public void handleUnmapped(String key, Object value) {
+      unmapped.put(key, value);
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getUnmapped() {
+      return unmapped;
+    }
+  }
+}

--- a/mod-pubsub-server/src/main/java/org/folio/rest/impl/ModTenantAPI.java
+++ b/mod-pubsub-server/src/main/java/org/folio/rest/impl/ModTenantAPI.java
@@ -45,7 +45,7 @@ public class ModTenantAPI extends TenantAPI {
             securityManager.createPubSubUser(params)
               .compose(ar -> securityManager.loginPubSubUser(params))
               .map(this::toObject)
-              .setHandler(blockingFuture);
+              .onComplete(blockingFuture);
           },
           result -> handleResult(result, postTenantAr, handler)
         );

--- a/mod-pubsub-server/src/main/java/org/folio/rest/impl/ModTenantAPI.java
+++ b/mod-pubsub-server/src/main/java/org/folio/rest/impl/ModTenantAPI.java
@@ -1,5 +1,8 @@
 package org.folio.rest.impl;
 
+import static io.vertx.core.Future.succeededFuture;
+import static org.folio.rest.jaxrs.resource.Tenant.PostTenantResponse.respond500WithTextPlain;
+
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Context;
 import io.vertx.core.Handler;
@@ -38,13 +41,30 @@ public class ModTenantAPI extends TenantAPI {
           blockingFuture -> {
             LiquibaseUtil.initializeSchemaForTenant(vertx, tenantId);
             OkapiConnectionParams params = new OkapiConnectionParams(headers, vertx);
+
             securityManager.createPubSubUser(params)
-              .compose(ar -> securityManager.loginPubSubUser(params));
-            blockingFuture.complete();
+              .compose(ar -> securityManager.loginPubSubUser(params))
+              .map(this::toObject)
+              .setHandler(blockingFuture);
           },
-          result -> handler.handle(postTenantAr)
+          result -> handleResult(result, postTenantAr, handler)
         );
       }
     }, context);
+  }
+
+  private <T> Object toObject(T specificType) {
+    return specificType;
+  }
+
+  private void handleResult(AsyncResult<Object> pubSubResult,
+    AsyncResult<Response> rmbMigrationResult, Handler<AsyncResult<Response>> handler) {
+
+    if (pubSubResult.succeeded()) {
+      handler.handle(rmbMigrationResult);
+    } else {
+      handler.handle(succeededFuture(respond500WithTextPlain(pubSubResult.cause()
+        .getMessage())));
+    }
   }
 }

--- a/mod-pubsub-server/src/main/java/org/folio/services/impl/SecurityManagerImpl.java
+++ b/mod-pubsub-server/src/main/java/org/folio/services/impl/SecurityManagerImpl.java
@@ -1,7 +1,11 @@
 package org.folio.services.impl;
 
+import static io.vertx.core.http.HttpMethod.PUT;
+import static io.vertx.core.json.Json.encode;
 import static java.lang.String.format;
 import static org.apache.commons.lang3.StringUtils.EMPTY;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+import static org.folio.HttpStatus.HTTP_NO_CONTENT;
 import static org.folio.rest.util.OkapiConnectionParams.OKAPI_TOKEN_HEADER;
 import static org.folio.rest.util.RestUtil.doRequest;
 
@@ -16,6 +20,7 @@ import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.folio.HttpStatus;
 import org.folio.dao.PubSubUserDao;
+import org.folio.representation.User;
 import org.folio.rest.util.OkapiConnectionParams;
 import org.folio.services.SecurityManager;
 import org.folio.services.cache.Cache;

--- a/mod-pubsub-server/src/main/java/org/folio/services/impl/SecurityManagerImpl.java
+++ b/mod-pubsub-server/src/main/java/org/folio/services/impl/SecurityManagerImpl.java
@@ -1,6 +1,33 @@
 package org.folio.services.impl;
 
+import static io.vertx.core.http.HttpMethod.PUT;
+import static io.vertx.core.json.Json.encode;
+import static java.lang.String.format;
+import static org.apache.commons.lang3.StringUtils.EMPTY;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+import static org.folio.HttpStatus.HTTP_NO_CONTENT;
+import static org.folio.rest.util.OkapiConnectionParams.OKAPI_TOKEN_HEADER;
+import static org.folio.rest.util.RestUtil.doRequest;
+
+import java.io.IOException;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.folio.HttpStatus;
+import org.folio.dao.PubSubUserDao;
+import org.folio.representation.User;
+import org.folio.rest.util.OkapiConnectionParams;
+import org.folio.services.SecurityManager;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
 import com.google.common.io.Resources;
+
 import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
@@ -10,26 +37,6 @@ import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
-import org.apache.commons.collections4.CollectionUtils;
-import org.apache.commons.lang3.StringUtils;
-import org.folio.HttpStatus;
-import org.folio.dao.PubSubUserDao;
-import org.folio.rest.util.OkapiConnectionParams;
-import org.folio.services.SecurityManager;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Component;
-
-import java.io.IOException;
-import java.net.URL;
-import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.UUID;
-
-import static java.lang.String.format;
-import static org.apache.commons.lang3.StringUtils.EMPTY;
-import static org.folio.rest.util.OkapiConnectionParams.OKAPI_TOKEN_HEADER;
-import static org.folio.rest.util.RestUtil.doRequest;
 
 @Component
 public class SecurityManagerImpl implements SecurityManager {
@@ -42,10 +49,11 @@ public class SecurityManagerImpl implements SecurityManager {
   private static final String PERMISSIONS_URL = "/perms/users";
   private static final String PERMISSIONS_FILE_PATH = "permissions/pubsub-user-permissions.csv";
   private static final String PUB_SUB_USERNAME = "pub-sub";
+  private static final String USER_LAST_NAME = "System";
   private static final String TOKEN_KEY_FORMAT = "%s_JWTToken";
 
-  private PubSubUserDao pubSubUserDao;
-  private Vertx vertx;
+  private final PubSubUserDao pubSubUserDao;
+  private final Vertx vertx;
 
   public SecurityManagerImpl(@Autowired PubSubUserDao pubSubUserDao, @Autowired Vertx vertx) {
     this.pubSubUserDao = pubSubUserDao;
@@ -82,9 +90,10 @@ public class SecurityManagerImpl implements SecurityManager {
   @Override
   public Future<Boolean> createPubSubUser(OkapiConnectionParams params) {
     return existsPubSubUser(params)
-      .compose(id -> {
-        if (StringUtils.isNotEmpty(id)) {
-          return addPermissions(id, params);
+      .compose(user -> {
+        if (user != null) {
+          return updateUser(user, params)
+            .compose(updatedUser -> addPermissions(user.getId(), params));
         } else {
           return createUser(params)
             .compose(userId -> saveCredentials(userId, params))
@@ -93,16 +102,16 @@ public class SecurityManagerImpl implements SecurityManager {
       });
   }
 
-  private Future<String> existsPubSubUser(OkapiConnectionParams params) {
+  private Future<User> existsPubSubUser(OkapiConnectionParams params) {
     String query = "?query=username=" + PUB_SUB_USERNAME;
     return doRequest(null, USERS_URL + query, HttpMethod.GET, params)
       .compose(response -> {
-        Promise<String> promise = Promise.promise();
+        Promise<User> promise = Promise.promise();
         if (response.statusCode() == HttpStatus.HTTP_OK.toInt()) {
           JsonObject usersCollection = response.bodyAsJsonObject();
           JsonArray users = usersCollection.getJsonArray("users");
           if (users.size() > 0) {
-            promise.complete(users.getJsonObject(0).getString("id"));
+            promise.complete(users.getJsonObject(0).mapTo(User.class));
           } else {
             promise.complete();
           }
@@ -115,12 +124,10 @@ public class SecurityManagerImpl implements SecurityManager {
   }
 
   private Future<String> createUser(OkapiConnectionParams params) {
-    String id = UUID.randomUUID().toString();
-    JsonObject body = new JsonObject()
-      .put("id", id)
-      .put("username", PUB_SUB_USERNAME)
-      .put("active", true);
-    return doRequest(body.encode(), USERS_URL, HttpMethod.POST, params)
+    final User user = createUserObject();
+    final String id = user.getId();
+
+    return doRequest(encode(user), USERS_URL, HttpMethod.POST, params)
       .compose(response -> {
         Promise<String> promise = Promise.promise();
         if (response.statusCode() == HttpStatus.HTTP_CREATED.toInt()) {
@@ -130,6 +137,30 @@ public class SecurityManagerImpl implements SecurityManager {
           String errorMessage = format("Failed to create pub-sub user. Received status code %s", response.statusCode());
           LOGGER.error(errorMessage);
           promise.fail(errorMessage);
+        }
+        return promise.future();
+      });
+  }
+
+  private Future<User> updateUser(User existingUser, OkapiConnectionParams params) {
+    if (existingUserUpToDate(existingUser)) {
+      LOGGER.info("The pub-sub user [{}] is up to date", existingUser.getId());
+      return Future.succeededFuture(existingUser);
+    }
+
+    LOGGER.info("Have to update the pub-sub user [{}]", existingUser.getId());
+
+    final User updatedUser = populateMissingUserProperties(existingUser);
+    final String url = updateUserUrl(updatedUser.getId());
+    return doRequest(encode(updatedUser), url, PUT, params)
+      .compose(response -> {
+        Promise<User> promise = Promise.promise();
+        if (response.statusCode() == HTTP_NO_CONTENT.toInt()) {
+          LOGGER.info("The pub-sub user [{}] has been updated", updatedUser.getId());
+          promise.complete(updatedUser);
+        } else {
+          LOGGER.error("Unable to update the pub-sub user [{}]", response.bodyAsString());
+          promise.fail("Unable to update the pub-sub user: " + response.bodyAsString());
         }
         return promise.future();
       });
@@ -223,4 +254,32 @@ public class SecurityManagerImpl implements SecurityManager {
     vertx.getOrCreateContext().put(format(TOKEN_KEY_FORMAT, params.getTenantId()), token);
   }
 
+  private User createUserObject() {
+    final User user = new User();
+
+    user.setId(UUID.randomUUID().toString());
+    user.setActive(true);
+    user.setUsername(PUB_SUB_USERNAME);
+
+    user.setPersonal(new User.Personal());
+    user.getPersonal().setLastName(USER_LAST_NAME);
+
+    return user;
+  }
+
+  private boolean existingUserUpToDate(User existingUser) {
+    return existingUser.getPersonal() != null
+      && isNotBlank(existingUser.getPersonal().getLastName());
+  }
+
+  private User populateMissingUserProperties(User existingUser) {
+    existingUser.setPersonal(new User.Personal());
+    existingUser.getPersonal().setLastName(USER_LAST_NAME);
+
+    return existingUser;
+  }
+
+  private String updateUserUrl(String userId) {
+    return USERS_URL + "/" + userId;
+  }
 }

--- a/mod-pubsub-server/src/test/java/org/folio/rest/impl/AbstractRestTest.java
+++ b/mod-pubsub-server/src/test/java/org/folio/rest/impl/AbstractRestTest.java
@@ -48,11 +48,12 @@ public abstract class AbstractRestTest {
 
   private static final String KAFKA_HOST = "KAFKA_HOST";
   private static final String KAFKA_PORT = "KAFKA_PORT";
-  private static final String OKAPI_URL = "OKAPI_URL";
+  private static final String OKAPI_URL_ENV = "OKAPI_URL";
+
+  private static final int PORT = NetworkUtils.nextFreePort();
+  protected static final String OKAPI_URL = "http://localhost:" + PORT;
 
   static RequestSpecification spec;
-  private static int port = NetworkUtils.nextFreePort();
-  private static String okapiUrl = "http://localhost:" + port;
   private static String useExternalDatabase;
   protected static Vertx vertx;
 
@@ -66,7 +67,7 @@ public abstract class AbstractRestTest {
     String[] hostAndPort = cluster.getBrokerList().split(":");
     System.setProperty(KAFKA_HOST, hostAndPort[0]);
     System.setProperty(KAFKA_PORT, hostAndPort[1]);
-    System.setProperty(OKAPI_URL, okapiUrl);
+    System.setProperty(OKAPI_URL_ENV, OKAPI_URL);
     deployVerticle(context);
   }
 
@@ -102,11 +103,11 @@ public abstract class AbstractRestTest {
   private static void deployVerticle(final TestContext context) {
     Async async = context.async();
 
-    TenantClient tenantClient = new TenantClient(okapiUrl, TENANT_ID, TOKEN);
+    TenantClient tenantClient = new TenantClient(OKAPI_URL, TENANT_ID, TOKEN);
 
     final DeploymentOptions options = new DeploymentOptions()
       .setConfig(new JsonObject()
-        .put(HTTP_PORT, port)
+        .put(HTTP_PORT, PORT)
         .put("spring.configuration", "org.folio.config.TestConfig"));
     vertx.deployVerticle(RestVerticle.class.getName(), options, res -> {
       try {
@@ -141,7 +142,7 @@ public abstract class AbstractRestTest {
     spec = new RequestSpecBuilder()
       .setContentType(ContentType.JSON)
       .addHeader(OKAPI_HEADER_TENANT, TENANT_ID)
-      .setBaseUri("http://localhost:" + port)
+      .setBaseUri("http://localhost:" + PORT)
       .addHeader("Accept", "text/plain, application/json")
       .build();
   }

--- a/mod-pubsub-server/src/test/java/org/folio/rest/impl/ModTenantApiTest.java
+++ b/mod-pubsub-server/src/test/java/org/folio/rest/impl/ModTenantApiTest.java
@@ -1,0 +1,88 @@
+package org.folio.rest.impl;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.any;
+import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.okJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.put;
+import static org.folio.rest.util.OkapiConnectionParams.OKAPI_URL_HEADER;
+import static org.junit.Assert.assertTrue;
+
+import java.util.UUID;
+
+import org.folio.representation.User;
+import org.folio.rest.jaxrs.model.TenantAttributes;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+
+import io.restassured.RestAssured;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+
+@RunWith(VertxUnitRunner.class)
+public class ModTenantApiTest extends AbstractRestTest {
+  private static final String MODULE_TO_VERSION = "mod-pubsub-1.0.0";
+  private static final String TENANT_URL = "/_/tenant";
+  private static final String USERS_URL = "/users";
+  private static final String GET_PUBSUB_USER_URL = USERS_URL + "?query=username=pub-sub";
+
+  @ClassRule
+  public static WireMockRule wireMockRule = new WireMockRule(
+    new WireMockConfiguration().dynamicPort());
+
+  @BeforeClass
+  public static void setUpProxying() {
+    // forward to okapi by default
+    wireMockRule.stubFor(any(anyUrl()).willReturn(aResponse().proxiedFrom(OKAPI_URL))
+      .atPriority(Integer.MAX_VALUE));
+  }
+
+  @Test
+  public void shouldForwardUserUpdateError() {
+    final String expectedErrorMessage = "User is broken";
+
+    final User user = existingUser();
+    final JsonObject userCollection = new JsonObject()
+      .put("users", new JsonArray().add(JsonObject.mapFrom(user)));
+
+    wireMockRule.stubFor(get(GET_PUBSUB_USER_URL)
+      .willReturn(okJson(userCollection.toString())));
+    wireMockRule.stubFor(put(userByIdUrl(user.getId()))
+      .willReturn(aResponse().withStatus(400).withBody(expectedErrorMessage)));
+
+    final String body = RestAssured.given()
+      .spec(spec)
+      .header(OKAPI_URL_HEADER, mockOkapiUrl())
+      .body(new TenantAttributes().withModuleTo(MODULE_TO_VERSION))
+      .when().post(TENANT_URL)
+      .then().statusCode(500)
+      .extract().body().asString();
+
+    assertTrue(body.contains(expectedErrorMessage));
+  }
+
+  private User existingUser() {
+    final User user = new User();
+
+    user.setId(UUID.randomUUID().toString());
+    user.setActive(true);
+    user.setUsername("pub-sub");
+
+    return user;
+  }
+
+  private String userByIdUrl(String id) {
+    return USERS_URL + "/" + id;
+  }
+
+  private String mockOkapiUrl() {
+    return "http://localhost:" + wireMockRule.port();
+  }
+}

--- a/mod-pubsub-server/src/test/java/org/folio/services/impl/SecurityManagerTest.java
+++ b/mod-pubsub-server/src/test/java/org/folio/services/impl/SecurityManagerTest.java
@@ -1,24 +1,40 @@
 package org.folio.services.impl;
 
-import com.github.tomakehurst.wiremock.client.WireMock;
-import com.github.tomakehurst.wiremock.common.Slf4jNotifier;
-import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
-import com.github.tomakehurst.wiremock.junit.WireMockRule;
-import com.github.tomakehurst.wiremock.matching.RequestPatternBuilder;
-import com.github.tomakehurst.wiremock.verification.LoggedRequest;
-import io.vertx.core.Context;
-import io.vertx.core.Future;
-import io.vertx.core.Vertx;
-import io.vertx.core.json.JsonArray;
-import io.vertx.core.json.JsonObject;
-import io.vertx.ext.unit.Async;
-import io.vertx.ext.unit.TestContext;
-import io.vertx.ext.unit.junit.VertxUnitRunner;
+import static com.github.tomakehurst.wiremock.client.WireMock.created;
+import static com.github.tomakehurst.wiremock.client.WireMock.findAll;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.noContent;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.put;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
+import static com.github.tomakehurst.wiremock.http.RequestMethod.POST;
+import static io.vertx.core.json.Json.decodeValue;
+import static org.folio.rest.RestVerticle.OKAPI_HEADER_TOKEN;
+import static org.folio.rest.util.OkapiConnectionParams.OKAPI_TENANT_HEADER;
+import static org.folio.rest.util.OkapiConnectionParams.OKAPI_TOKEN_HEADER;
+import static org.folio.rest.util.OkapiConnectionParams.OKAPI_URL_HEADER;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
 import org.folio.dao.PostgresClientFactory;
 import org.folio.dao.PubSubUserDao;
 import org.folio.dao.impl.PubSubUserDaoImpl;
+import org.folio.representation.User;
 import org.folio.rest.impl.AbstractRestTest;
 import org.folio.rest.util.OkapiConnectionParams;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -27,21 +43,20 @@ import org.mockito.InjectMocks;
 import org.mockito.MockitoAnnotations;
 import org.mockito.Spy;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
+import com.github.tomakehurst.wiremock.common.Slf4jNotifier;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import com.github.tomakehurst.wiremock.matching.RequestPatternBuilder;
+import com.github.tomakehurst.wiremock.verification.LoggedRequest;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
-import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
-import static com.github.tomakehurst.wiremock.client.WireMock.verify;
-import static org.folio.rest.RestVerticle.OKAPI_HEADER_TOKEN;
-import static org.folio.rest.util.OkapiConnectionParams.OKAPI_TENANT_HEADER;
-import static org.folio.rest.util.OkapiConnectionParams.OKAPI_TOKEN_HEADER;
-import static org.folio.rest.util.OkapiConnectionParams.OKAPI_URL_HEADER;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.when;
+import io.vertx.core.Context;
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
 
 @RunWith(VertxUnitRunner.class)
 public class SecurityManagerTest extends AbstractRestTest {
@@ -55,18 +70,18 @@ public class SecurityManagerTest extends AbstractRestTest {
   private static final String TOKEN = "token";
   private static final String TOKEN_KEY_FORMAT = "%s_JWTToken";
 
-  private Map<String, String> headers = new HashMap<>();
+  private final Map<String, String> headers = new HashMap<>();
 
   @Spy
-  private Vertx vertx = Vertx.vertx();
+  private final Vertx vertx = Vertx.vertx();
   @Spy
-  PostgresClientFactory postgresClientFactory = new PostgresClientFactory(vertx);
+  private final PostgresClientFactory postgresClientFactory = new PostgresClientFactory(vertx);
   @InjectMocks
-  private PubSubUserDao pubSubUserDao = new PubSubUserDaoImpl();
+  private final PubSubUserDao pubSubUserDao = new PubSubUserDaoImpl();
   @Spy
-  private SecurityManagerImpl securityManager = new SecurityManagerImpl(pubSubUserDao, vertx);
+  private final SecurityManagerImpl securityManager = new SecurityManagerImpl(pubSubUserDao, vertx);
 
-  private Context vertxContext = vertx.getOrCreateContext();
+  private final Context vertxContext = vertx.getOrCreateContext();
 
   @Rule
   public WireMockRule mockServer = new WireMockRule(
@@ -90,8 +105,8 @@ public class SecurityManagerTest extends AbstractRestTest {
 
     String pubSubToken = UUID.randomUUID().toString();
 
-    WireMock.stubFor(WireMock.post(LOGIN_URL)
-      .willReturn(WireMock.created().withHeader(OKAPI_HEADER_TOKEN, pubSubToken)));
+    stubFor(post(LOGIN_URL)
+      .willReturn(created().withHeader(OKAPI_HEADER_TOKEN, pubSubToken)));
 
     OkapiConnectionParams params = new OkapiConnectionParams();
     params.setVertx(vertx);
@@ -105,7 +120,7 @@ public class SecurityManagerTest extends AbstractRestTest {
     future.setHandler(ar -> {
       assertTrue(ar.succeeded());
       assertEquals(pubSubToken, ar.result());
-      List<LoggedRequest> requests = WireMock.findAll(RequestPatternBuilder.allRequests());
+      List<LoggedRequest> requests = findAll(RequestPatternBuilder.allRequests());
       assertEquals(1, requests.size());
       assertEquals(LOGIN_URL, requests.get(0).getUrl());
       assertEquals("POST", requests.get(0).getMethod().getName());
@@ -117,79 +132,75 @@ public class SecurityManagerTest extends AbstractRestTest {
 
   @Test
   public void shouldNotCreatePubSubUserIfItExists(TestContext context) {
-    Async async = context.async();
-
     String userId = UUID.randomUUID().toString();
     String userCollection = new JsonObject()
-      .put("users", new JsonArray()
-        .add(new JsonObject()
-          .put("username", "pub-sub")
-          .put("id", userId)))
+      .put("users", new JsonArray().add(existingUpToDateUser(userId)))
       .put("totalRecords", 1).encode();
-    String permUrl = PERMISSIONS_URL + "/" + userId + "/permissions?indexField=userId";
 
-    WireMock.stubFor(WireMock.get(USERS_URL_WITH_QUERY)
-      .willReturn(WireMock.ok().withBody(userCollection)));
-    WireMock.stubFor(WireMock.post(permUrl)
-      .willReturn(WireMock.ok()));
+    stubFor(get(USERS_URL_WITH_QUERY).willReturn(ok().withBody(userCollection)));
+    stubFor(post(permissionsByUserIdUrl(userId)).willReturn(ok()));
 
     OkapiConnectionParams params = new OkapiConnectionParams(headers, vertx);
 
     Future<Boolean> future = securityManager.createPubSubUser(params);
 
-    future.setHandler(ar -> {
-      assertTrue(ar.succeeded());
-      assertTrue(ar.result());
-      List<LoggedRequest> requests = WireMock.findAll(RequestPatternBuilder.allRequests());
+    future.map(ar -> {
+      assertTrue(ar);
+
+      List<LoggedRequest> requests = findAll(RequestPatternBuilder.allRequests());
       assertEquals(2, requests.size());
+
       assertEquals(USERS_URL_WITH_QUERY, requests.get(0).getUrl());
       assertEquals("GET", requests.get(0).getMethod().getName());
-      assertEquals(permUrl, requests.get(1).getUrl());
+
+      assertEquals(permissionsByUserIdUrl(userId), requests.get(1).getUrl());
       assertEquals("POST", requests.get(1).getMethod().getName());
-      async.complete();
-    });
+
+      // Verify user create request has not sent
+      verify(0, new RequestPatternBuilder(POST, urlEqualTo(USERS_URL)));
+
+      return null;
+    }).setHandler(context.asyncAssertSuccess());
   }
 
   @Test
   public void shouldCreatePubSubUser(TestContext context) {
-    Async async = context.async();
-
     String userId = UUID.randomUUID().toString();
     String userCollection = new JsonObject()
-      .put("users", new JsonArray()
-        .add(new JsonObject()
-          .put("username", "pub-sub")
-          .put("id", userId)))
+      .put("users", new JsonArray().add(existingUser(userId)))
       .put("totalRecords", 1).encode();
 
-    WireMock.stubFor(WireMock.get(USERS_URL_WITH_QUERY)
-      .willReturn(WireMock.ok().withBody(new JsonObject().put("users", new JsonArray()).encode())));
-    WireMock.stubFor(WireMock.post(USERS_URL)
-      .willReturn(WireMock.created().withBody(userCollection)));
-    WireMock.stubFor(WireMock.post(CREDENTIALS_URL)
-      .willReturn(WireMock.created()));
-    WireMock.stubFor(WireMock.post(PERMISSIONS_URL)
-      .willReturn(WireMock.created()));
+    stubFor(get(USERS_URL_WITH_QUERY)
+      .willReturn(ok().withBody(emptyUsersResponse().encode())));
+    stubFor(post(USERS_URL).willReturn(created().withBody(userCollection)));
+    stubFor(post(CREDENTIALS_URL).willReturn(created()));
+    stubFor(post(PERMISSIONS_URL).willReturn(created()));
 
     OkapiConnectionParams params = new OkapiConnectionParams(headers, vertx);
 
     Future<Boolean> future = securityManager.createPubSubUser(params);
 
-    future.setHandler(ar -> {
-      assertTrue(ar.succeeded());
-      assertTrue(ar.result());
-      List<LoggedRequest> requests = WireMock.findAll(RequestPatternBuilder.allRequests());
+    future.map(ar -> {
+      assertTrue(ar);
+
+      List<LoggedRequest> requests = findAll(RequestPatternBuilder.allRequests());
       assertEquals(4, requests.size());
+
       assertEquals(USERS_URL_WITH_QUERY, requests.get(0).getUrl());
       assertEquals("GET", requests.get(0).getMethod().getName());
+
       assertEquals(USERS_URL, requests.get(1).getUrl());
       assertEquals("POST", requests.get(1).getMethod().getName());
+      verifyUser(requests.get(1));
+
       assertEquals(CREDENTIALS_URL, requests.get(2).getUrl());
       assertEquals("POST", requests.get(2).getMethod().getName());
+
       assertEquals(PERMISSIONS_URL, requests.get(3).getUrl());
       assertEquals("POST", requests.get(3).getMethod().getName());
-      async.complete();
-    });
+
+      return null;
+    }).setHandler(context.asyncAssertSuccess());
   }
 
   @Test
@@ -197,8 +208,8 @@ public class SecurityManagerTest extends AbstractRestTest {
     Async async = context.async();
     String expectedToken = UUID.randomUUID().toString();
 
-    WireMock.stubFor(WireMock.post(LOGIN_URL)
-      .willReturn(WireMock.created().withHeader(OKAPI_HEADER_TOKEN, expectedToken)));
+    stubFor(post(LOGIN_URL)
+      .willReturn(created().withHeader(OKAPI_HEADER_TOKEN, expectedToken)));
 
     OkapiConnectionParams params = new OkapiConnectionParams(headers, vertx);
 
@@ -212,4 +223,111 @@ public class SecurityManagerTest extends AbstractRestTest {
     });
   }
 
+  @Test
+  public void shouldUpdateExistingUser(TestContext context) {
+    final String userId = UUID.randomUUID().toString();
+    final String permUrl = PERMISSIONS_URL + "/" + userId + "/permissions?indexField=userId";
+    final String userCollection = new JsonObject()
+      .put("users", new JsonArray().add(existingUser(userId)))
+      .put("totalRecords", 1).encode();
+
+    stubFor(get(USERS_URL_WITH_QUERY).willReturn(ok().withBody(userCollection)));
+    stubFor(put(USERS_URL + "/" + userId).willReturn(noContent()));
+    stubFor(post(permUrl).willReturn(ok()));
+
+    OkapiConnectionParams params = new OkapiConnectionParams(headers, vertx);
+
+    Future<Boolean> future = securityManager.createPubSubUser(params);
+
+    future.map(ar -> {
+      assertTrue(ar);
+
+      final List<LoggedRequest> requests = findAll(RequestPatternBuilder.allRequests());
+      assertEquals(3, requests.size());
+
+      assertEquals(USERS_URL_WITH_QUERY, requests.get(0).getUrl());
+      assertEquals("GET", requests.get(0).getMethod().getName());
+
+      assertEquals(USERS_URL + "/" + userId, requests.get(1).getUrl());
+      assertEquals("PUT", requests.get(1).getMethod().getName());
+      verifyUser(requests.get(1));
+
+      assertEquals(permUrl, requests.get(2).getUrl());
+      assertEquals("POST", requests.get(2).getMethod().getName());
+
+      return null;
+    }).setHandler(context.asyncAssertSuccess());
+  }
+
+  @Test
+  public void shouldNotUpdateExistingUserIfUpToDate(TestContext context) {
+    final String userId = UUID.randomUUID().toString();
+    final String userCollection = new JsonObject()
+      .put("users", new JsonArray().add(existingUpToDateUser(userId)))
+      .put("totalRecords", 1).encode();
+
+    stubFor(get(USERS_URL_WITH_QUERY).willReturn(ok().withBody(userCollection)));
+    stubFor(post(permissionsByUserIdUrl(userId)).willReturn(ok()));
+
+    OkapiConnectionParams params = new OkapiConnectionParams(headers, vertx);
+
+    Future<Boolean> future = securityManager.createPubSubUser(params);
+
+    future.map(ar -> {
+      assertTrue(ar);
+
+      final List<LoggedRequest> requests = findAll(RequestPatternBuilder.allRequests());
+      assertEquals(2, requests.size());
+
+      assertEquals(USERS_URL_WITH_QUERY, requests.get(0).getUrl());
+      assertEquals("GET", requests.get(0).getMethod().getName());
+
+      assertEquals(permissionsByUserIdUrl(userId), requests.get(1).getUrl());
+      assertEquals("POST", requests.get(1).getMethod().getName());
+
+      return null;
+    }).setHandler(context.asyncAssertSuccess());
+  }
+
+  private void verifyUser(LoggedRequest loggedRequest) {
+    final User user = decodeValue(loggedRequest.getBodyAsString(), User.class);
+
+    assertNotNull(user.getId());
+    assertTrue(user.isActive());
+    assertEquals("pub-sub", user.getUsername());
+
+    assertNotNull(user.getPersonal());
+    assertEquals("System", user.getPersonal().getLastName());
+  }
+
+  private JsonObject existingUser(String id) {
+    final JsonObject metadata = new JsonObject()
+      .put("createdDate", DateTime.now(DateTimeZone.UTC).toString())
+      .put("updatedDate", DateTime.now(DateTimeZone.UTC).toString());
+
+    return new JsonObject()
+      .put("id", id)
+      .put("username", "pub-sub")
+      .put("active", "true")
+      .put("proxyFor", new JsonArray())
+      .put("createdDate", DateTime.now(DateTimeZone.UTC).toString())
+      .put("updatedDate", DateTime.now(DateTimeZone.UTC).toString())
+      .put("metadata", metadata);
+  }
+
+  private JsonObject existingUpToDateUser(String id) {
+    final JsonObject personal = new JsonObject()
+      .put("lastName", "System")
+      .put("addresses", new JsonArray());
+
+    return existingUser(id).put("personal", personal);
+  }
+
+  private String permissionsByUserIdUrl(String userId) {
+    return PERMISSIONS_URL + "/" + userId + "/permissions?indexField=userId";
+  }
+
+  private JsonObject emptyUsersResponse() {
+    return new JsonObject().put("users", new JsonArray());
+  }
 }


### PR DESCRIPTION
https://issues.folio.org/browse/MODPUBSUB-107 - Show **system** as source in loan action table when lost item fees are paid


## Purpose

Since mod-circulation integration with pub-sub it is required to have a last name for the user in order to properly display source of action at loan action page.

Emma has discussed it with RA SIG and they decided to use **System** as an human identifier of the user (i.e. the last name).

## Changes

* Add `personal.lastName` property to user json that used [to create the user](https://github.com/folio-org/mod-pubsub/pull/88/files#diff-f11076db34e5ecca90023354b89b08baR250);
* [Do update](https://github.com/folio-org/mod-pubsub/pull/88/files#diff-f11076db34e5ecca90023354b89b08baR142) of the existing user if the property is not present (to cover migration case);
* Add some tests to verify the changes;
* [Forward user update failure](https://github.com/folio-org/mod-pubsub/pull/88/files#diff-7455f115aea6bcad69b2af2de5ec9e11) to `/_/tenant` response and verify it. 