### PR TITLE
MODPUBSUB-145:Add permissions for pubsub user on re-login.

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -282,6 +282,11 @@
       "permissionName": "pubsub.messaging-modules.delete",
       "displayName": "PubSub - delete publishers and subscribers declarations",
       "description": "Delete publishers or subscribers"
+    },
+    {
+      "permissionName": "pubsub.events.post",
+      "displayName": "PubSub - post event.",
+      "description": "Post all events."
     }
   ],
   "launchDescriptor": {

--- a/mod-pubsub-server/src/main/resources/permissions/pubsub-user-permissions.csv
+++ b/mod-pubsub-server/src/main/resources/permissions/pubsub-user-permissions.csv
@@ -1,6 +1,1 @@
-source-storage.events.post
-source-records-manager.events.post
-inventory.events.post
-circulation.events.post
-patron-blocks.events.post
-audit-data.events.post
+pubsub.events.post


### PR DESCRIPTION
## Purpose
1. Permissions logic changed.

## Approach
Unite all permissions in "pubsub.events.post".

## Learning
More info: https://issues.folio.org/browse/MODPUBSUB-145
