### PR TITLE
Fix tenant init MODPUBSUB-148

### DIFF
--- a/mod-pubsub-server/pom.xml
+++ b/mod-pubsub-server/pom.xml
@@ -295,10 +295,6 @@
         <configuration>
           <verbose>true</verbose>
           <complianceLevel>11</complianceLevel>
-          <includes>
-            <include>**/impl/*.java</include>
-            <include>**/*.aj</include>
-          </includes>
           <aspectDirectory>src/main/java/org/folio/rest/annotations</aspectDirectory>
           <XaddSerialVersionUID>true</XaddSerialVersionUID>
           <showWeaveInfo>true</showWeaveInfo>

--- a/mod-pubsub-server/src/test/java/org/folio/rest/impl/ModTenantApiTest.java
+++ b/mod-pubsub-server/src/test/java/org/folio/rest/impl/ModTenantApiTest.java
@@ -62,7 +62,7 @@ public class ModTenantApiTest extends AbstractRestTest {
       .header(OKAPI_URL_HEADER, mockOkapiUrl())
       .body(JsonObject.mapFrom(new TenantAttributes().withModuleTo(MODULE_TO_VERSION)).encode())
       .when().post(TENANT_URL)
-      .then().statusCode(500)
+      .then().statusCode(400)
       .extract().body().asString();
 
   }


### PR DESCRIPTION
Several problems with this implementation:

1: handler was called without proper response type. It should be
someting like Future.succeededFuture(PostTenantResponse.responseWith...)
Not doing this right will make RMB throw 500.

2: Liquibase and user created always (also when module is disabled
or even purged).

3: using postTenantSync was meant to be used for UNIT TESTING and not
for production code. This means that database setup which may take
a while will be blocking. But it's not a show-stopper.

This commit just makes the post stuff to happen in loadData. This is called
on create/upgrade of a tenant. It also has a much simpler API. However,
because mod-pubsub unit tests aren't set up for async operation, the
super.postTenantSync is kept for now. It should eventually removed, so
that postTenant does not need any overriding at all.