### PR TITLE
MODPUBSUB-150 Use "replaces" for deprecated permissions replaced by a new permission

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -289,7 +289,15 @@
     {
       "permissionName": "pubsub.events.post",
       "displayName": "PubSub - post event.",
-      "description": "Post all events."
+      "description": "Post all events.",
+      "replaces": [
+        "source-storage.events.post",
+        "source-records-manager.events.post",
+        "inventory.events.post",
+        "circulation.events.post",
+        "patron-blocks.events.post",
+        "audit-data.events.post"
+      ]
     }
   ],
   "launchDescriptor": {


### PR DESCRIPTION
## Purpose
Rather then simply removing no longer used permissions like `inventory.events.post` and `audit.events.post` replacing them with `pubsub.events.post`, use the "replaces" field so that the users assigned any of those old permissions are automatically granted the new one.  For instance, see https://github.com/folio-org/mod-pubsub/pull/124/files

## Approach
Use the replaces property in the ModuleDescriptor

## Context/Links
* https://issues.folio.org/browse/MODPUBSUB-150
* https://github.com/folio-org/mod-pubsub/pull/124/files
