### PR TITLE
MODPUBSUB-152 

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,6 @@
-## 2021-02-23 v2.1.0-SNAPSHOT
+## xxxx-xx-xx v2.1.0-SNAPSHOT
+
+## 2021-03-06 v2.0.1
 * [MODPUBSUB-152](https://issues.folio.org/browse/MODPUBSUB-152) Module registration in mod-pubsub fails when MessagingDescriptor contains no publications
 
 ## 2021-02-22 v2.0.0

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+## 2021-02-23 v2.1.0-SNAPSHOT
+* [MODPUBSUB-152](https://issues.folio.org/browse/MODPUBSUB-152) Module registration in mod-pubsub fails when MessagingDescriptor contains no publications
+
 ## 2021-02-22 v2.0.0
 * [MODPUBSUB-87](https://issues.folio.org/browse/MODPUBSUB-87) Create utility method for module unregistering
 * [MODPUBSUB-118](https://issues.folio.org/browse/MODPUBSUB-118) Create sub-project in mod-pubsub for utility transport layer classes

--- a/mod-pubsub-client/src/main/java/org/folio/util/pubsub/PubSubClientUtils.java
+++ b/mod-pubsub-client/src/main/java/org/folio/util/pubsub/PubSubClientUtils.java
@@ -85,7 +85,7 @@ public class PubSubClientUtils {
    * @return - async result with boolean value. True if module was registered successfully
    */
   public static CompletableFuture<Boolean> registerModule(OkapiConnectionParams params) {
-    CompletableFuture<Boolean> result = new CompletableFuture<>();
+    CompletableFuture<Boolean> result = null;
     PubsubClient client = new PubsubClient(params.getOkapiUrl(), params.getTenantId(), params.getToken());
     try {
       LOGGER.info("Reading MessagingDescriptor.json");
@@ -99,11 +99,11 @@ public class PubSubClientUtils {
       }
       if (descriptorHolder.getSubscriberDescriptor() != null &&
         isNotEmpty(descriptorHolder.getSubscriberDescriptor().getSubscriptionDefinitions())) {
-        result = result.thenCompose(ar -> registerSubscribers(client, descriptorHolder.getSubscriberDescriptor()));
+        result = registerSubscribers(client, descriptorHolder.getSubscriberDescriptor());
       }
     } catch (Exception e) {
       LOGGER.error("Error during registration module in PubSub", e);
-      result.completeExceptionally(e);
+      result = CompletableFuture.failedFuture(e);
     }
     return result;
   }

--- a/mod-pubsub-client/src/main/java/org/folio/util/pubsub/PubSubClientUtils.java
+++ b/mod-pubsub-client/src/main/java/org/folio/util/pubsub/PubSubClientUtils.java
@@ -85,7 +85,7 @@ public class PubSubClientUtils {
    * @return - async result with boolean value. True if module was registered successfully
    */
   public static CompletableFuture<Boolean> registerModule(OkapiConnectionParams params) {
-    CompletableFuture<Boolean> result = null;
+    CompletableFuture<Boolean> result = CompletableFuture.completedFuture(false);
     PubsubClient client = new PubsubClient(params.getOkapiUrl(), params.getTenantId(), params.getToken());
     try {
       LOGGER.info("Reading MessagingDescriptor.json");
@@ -99,7 +99,7 @@ public class PubSubClientUtils {
       }
       if (descriptorHolder.getSubscriberDescriptor() != null &&
         isNotEmpty(descriptorHolder.getSubscriberDescriptor().getSubscriptionDefinitions())) {
-        result = registerSubscribers(client, descriptorHolder.getSubscriberDescriptor());
+        result = result.thenCompose(ar -> registerSubscribers(client, descriptorHolder.getSubscriberDescriptor()));
       }
     } catch (Exception e) {
       LOGGER.error("Error during registration module in PubSub", e);

--- a/mod-pubsub-client/src/test/java/org/folio/config/TestConfig.java
+++ b/mod-pubsub-client/src/test/java/org/folio/config/TestConfig.java
@@ -1,6 +1,5 @@
 package org.folio.config;
 
-import org.folio.config.ApplicationConfig;
 import org.springframework.context.annotation.Import;
 
 @Import(ApplicationConfig.class)

--- a/mod-pubsub-client/src/test/java/org/folio/util/pubsub/PubSubClientTest.java
+++ b/mod-pubsub-client/src/test/java/org/folio/util/pubsub/PubSubClientTest.java
@@ -6,13 +6,10 @@ import com.github.tomakehurst.wiremock.matching.UrlPathPattern;
 import io.restassured.RestAssured;
 import io.restassured.response.Response;
 import io.vertx.core.json.JsonObject;
-import io.vertx.ext.unit.Async;
-import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import org.apache.http.HttpStatus;
 import org.folio.rest.jaxrs.model.Event;
 import org.folio.rest.jaxrs.model.EventDescriptor;
-import org.folio.rest.jaxrs.model.MessagingModule;
 import org.folio.rest.jaxrs.model.PublisherDescriptor;
 import org.folio.rest.jaxrs.model.SubscriberDescriptor;
 import org.folio.rest.jaxrs.model.SubscriptionDefinition;
@@ -24,13 +21,11 @@ import org.junit.runner.RunWith;
 
 import java.util.Collections;
 import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.badRequest;
 import static com.github.tomakehurst.wiremock.client.WireMock.created;
 import static com.github.tomakehurst.wiremock.client.WireMock.delete;
-import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.serverError;
 import static org.hamcrest.Matchers.is;
@@ -75,6 +70,8 @@ public class PubSubClientTest extends AbstractRestTest {
   @Test
   public void shouldNotRegisterPublishers() {
     WireMock.stubFor(post("/pubsub/event-types/declare/publisher")
+      .willReturn(badRequest()));
+    WireMock.stubFor(post("/pubsub/event-types/declare/subscriber")
       .willReturn(badRequest()));
     WireMock.stubFor(post("/pubsub/event-types")
       .willReturn(created()));

--- a/mod-pubsub-client/src/test/java/org/folio/util/pubsub/PubSubClientTest.java
+++ b/mod-pubsub-client/src/test/java/org/folio/util/pubsub/PubSubClientTest.java
@@ -14,7 +14,6 @@ import org.folio.rest.jaxrs.model.PublisherDescriptor;
 import org.folio.rest.jaxrs.model.SubscriberDescriptor;
 import org.folio.rest.jaxrs.model.SubscriptionDefinition;
 import org.folio.rest.util.OkapiConnectionParams;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -29,6 +28,9 @@ import static com.github.tomakehurst.wiremock.client.WireMock.delete;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.serverError;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 @RunWith(VertxUnitRunner.class)
 public class PubSubClientTest extends AbstractRestTest {
@@ -64,7 +66,7 @@ public class PubSubClientTest extends AbstractRestTest {
 
   @Test
   public void registerModuleSuccessfully() throws Exception {
-    Assert.assertTrue(PubSubClientUtils.registerModule(params).get());
+    assertTrue(PubSubClientUtils.registerModule(params).get());
   }
 
   @Test
@@ -77,9 +79,9 @@ public class PubSubClientTest extends AbstractRestTest {
       .willReturn(created()));
     try {
       PubSubClientUtils.registerModule(fakeParams).get();
-      Assert.fail();
+      fail();
     } catch (Exception e) {
-      Assert.assertTrue(true);
+      assertTrue(true);
     }
   }
 
@@ -93,9 +95,9 @@ public class PubSubClientTest extends AbstractRestTest {
       .willReturn(badRequest()));
     try {
       PubSubClientUtils.registerModule(fakeParams).get();
-      Assert.fail();
+      fail();
     } catch (Exception e) {
-      Assert.assertTrue(true);
+      assertTrue(true);
     }
   }
 
@@ -105,9 +107,9 @@ public class PubSubClientTest extends AbstractRestTest {
     registerPublisher(eventDescriptor);
     try {
       Event event = EVENT.mapTo(Event.class);
-      Assert.assertTrue(PubSubClientUtils.sendEventMessage(event, params).get());
+      assertTrue(PubSubClientUtils.sendEventMessage(event, params).get());
     } catch (Exception e) {
-      Assert.fail();
+      fail();
     }
   }
 
@@ -119,15 +121,15 @@ public class PubSubClientTest extends AbstractRestTest {
 
     try {
       Event event = EVENT.mapTo(Event.class);
-      Assert.assertTrue(PubSubClientUtils.sendEventMessage(event, params).get());
+      assertTrue(PubSubClientUtils.sendEventMessage(event, params).get());
     } catch (Exception e) {
-      Assert.fail();
+      fail();
     }
   }
 
   @Test
   public void shouldUnregisterModuleSuccessfully() throws Exception {
-    Assert.assertTrue(PubSubClientUtils.unregisterModule(params).get());
+    assertTrue(PubSubClientUtils.unregisterModule(params).get());
   }
 
   @Test(expected = ExecutionException.class)
@@ -147,7 +149,7 @@ public class PubSubClientTest extends AbstractRestTest {
       .body(JsonObject.mapFrom(publisherDescriptor).encode())
       .when()
       .post(EVENT_TYPES_PATH + DECLARE_PUBLISHER_PATH);
-    Assert.assertThat(postResponse.statusCode(), is(HttpStatus.SC_CREATED));
+    assertThat(postResponse.statusCode(), is(HttpStatus.SC_CREATED));
   }
 
   private EventDescriptor postEventDescriptor() {
@@ -156,7 +158,7 @@ public class PubSubClientTest extends AbstractRestTest {
       .body(JsonObject.mapFrom(PubSubClientTest.EVENT_DESCRIPTOR).encode())
       .when()
       .post(EVENT_TYPES_PATH);
-    Assert.assertThat(postResponse.statusCode(), is(HttpStatus.SC_CREATED));
+    assertThat(postResponse.statusCode(), is(HttpStatus.SC_CREATED));
     return new JsonObject(postResponse.body().asString()).mapTo(EventDescriptor.class);
   }
 
@@ -173,7 +175,7 @@ public class PubSubClientTest extends AbstractRestTest {
       .body(JsonObject.mapFrom(subscriberDescriptor).encode())
       .when()
       .post(EVENT_TYPES_PATH + DECLARE_SUBSCRIBER_PATH);
-    Assert.assertThat(postResponse.statusCode(), is(HttpStatus.SC_CREATED));
+    assertThat(postResponse.statusCode(), is(HttpStatus.SC_CREATED));
   }
 
 }

--- a/mod-pubsub-client/src/test/java/org/folio/util/pubsub/PubSubClientUtilsTest.java
+++ b/mod-pubsub-client/src/test/java/org/folio/util/pubsub/PubSubClientUtilsTest.java
@@ -2,7 +2,6 @@ package org.folio.util.pubsub;
 
 import org.folio.util.pubsub.support.DescriptorHolder;
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -15,6 +14,8 @@ import static org.folio.util.pubsub.PubSubClientUtils.MESSAGING_CONFIG_PATH_PROP
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.isEmptyOrNullString;
 import static org.hamcrest.Matchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertNotNull;
 
 public class PubSubClientUtilsTest {
 
@@ -35,12 +36,12 @@ public class PubSubClientUtilsTest {
   public void shouldReadMessagingDescriptorByDefaultPathAndReturnFilledDescriptorHolder() throws IOException {
     DescriptorHolder descriptorHolder = PubSubClientUtils.readMessagingDescriptor();
 
-    Assert.assertNotNull(descriptorHolder.getPublisherDescriptor());
-    Assert.assertNotNull(descriptorHolder.getSubscriberDescriptor());
-    Assert.assertThat(descriptorHolder.getPublisherDescriptor().getModuleId(), not(isEmptyOrNullString()));
-    Assert.assertThat(descriptorHolder.getPublisherDescriptor().getEventDescriptors().size(), is(1));
-    Assert.assertThat(descriptorHolder.getSubscriberDescriptor().getModuleId(), not(isEmptyOrNullString()));
-    Assert.assertThat(descriptorHolder.getSubscriberDescriptor().getSubscriptionDefinitions().size(), is(1));
+    assertNotNull(descriptorHolder.getPublisherDescriptor());
+    assertNotNull(descriptorHolder.getSubscriberDescriptor());
+    assertThat(descriptorHolder.getPublisherDescriptor().getModuleId(), not(isEmptyOrNullString()));
+    assertThat(descriptorHolder.getPublisherDescriptor().getEventDescriptors().size(), is(1));
+    assertThat(descriptorHolder.getSubscriberDescriptor().getModuleId(), not(isEmptyOrNullString()));
+    assertThat(descriptorHolder.getSubscriberDescriptor().getSubscriptionDefinitions().size(), is(1));
   }
 
   @Test
@@ -49,12 +50,12 @@ public class PubSubClientUtilsTest {
 
     DescriptorHolder descriptorHolder = PubSubClientUtils.readMessagingDescriptor();
 
-    Assert.assertNotNull(descriptorHolder.getPublisherDescriptor());
-    Assert.assertNotNull(descriptorHolder.getSubscriberDescriptor());
-    Assert.assertThat(descriptorHolder.getPublisherDescriptor().getModuleId(), not(isEmptyOrNullString()));
-    Assert.assertThat(descriptorHolder.getPublisherDescriptor().getEventDescriptors().size(), is(1));
-    Assert.assertThat(descriptorHolder.getSubscriberDescriptor().getModuleId(), not(isEmptyOrNullString()));
-    Assert.assertThat(descriptorHolder.getSubscriberDescriptor().getSubscriptionDefinitions().size(), is(2));
+    assertNotNull(descriptorHolder.getPublisherDescriptor());
+    assertNotNull(descriptorHolder.getSubscriberDescriptor());
+    assertThat(descriptorHolder.getPublisherDescriptor().getModuleId(), not(isEmptyOrNullString()));
+    assertThat(descriptorHolder.getPublisherDescriptor().getEventDescriptors().size(), is(1));
+    assertThat(descriptorHolder.getSubscriberDescriptor().getModuleId(), not(isEmptyOrNullString()));
+    assertThat(descriptorHolder.getSubscriberDescriptor().getSubscriptionDefinitions().size(), is(2));
   }
 
   @Test
@@ -64,12 +65,12 @@ public class PubSubClientUtilsTest {
 
     DescriptorHolder descriptorHolder = PubSubClientUtils.readMessagingDescriptor();
 
-    Assert.assertNotNull(descriptorHolder.getPublisherDescriptor());
-    Assert.assertNotNull(descriptorHolder.getSubscriberDescriptor());
-    Assert.assertThat(descriptorHolder.getPublisherDescriptor().getModuleId(), not(isEmptyOrNullString()));
-    Assert.assertThat(descriptorHolder.getPublisherDescriptor().getEventDescriptors().size(), is(1));
-    Assert.assertThat(descriptorHolder.getSubscriberDescriptor().getModuleId(), not(isEmptyOrNullString()));
-    Assert.assertThat(descriptorHolder.getSubscriberDescriptor().getSubscriptionDefinitions().size(), is(1));
+    assertNotNull(descriptorHolder.getPublisherDescriptor());
+    assertNotNull(descriptorHolder.getSubscriberDescriptor());
+    assertThat(descriptorHolder.getPublisherDescriptor().getModuleId(), not(isEmptyOrNullString()));
+    assertThat(descriptorHolder.getPublisherDescriptor().getEventDescriptors().size(), is(1));
+    assertThat(descriptorHolder.getSubscriberDescriptor().getModuleId(), not(isEmptyOrNullString()));
+    assertThat(descriptorHolder.getSubscriberDescriptor().getSubscriptionDefinitions().size(), is(1));
   }
 
   @Test

--- a/mod-pubsub-server/src/test/java/org/folio/rest/impl/EventTypeAPITest.java
+++ b/mod-pubsub-server/src/test/java/org/folio/rest/impl/EventTypeAPITest.java
@@ -7,12 +7,12 @@ import io.vertx.ext.unit.junit.VertxUnitRunner;
 import org.apache.http.HttpStatus;
 import org.folio.rest.jaxrs.model.EventDescriptor;
 import org.folio.rest.jaxrs.model.PublisherDescriptor;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import java.util.Collections;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
 
@@ -252,7 +252,7 @@ public class EventTypeAPITest extends AbstractRestTest {
       .body(JsonObject.mapFrom(eventDescriptor).encode())
       .when()
       .post(EVENT_TYPES_PATH);
-    Assert.assertThat(postResponse.statusCode(), is(HttpStatus.SC_CREATED));
+    assertThat(postResponse.statusCode(), is(HttpStatus.SC_CREATED));
     return new JsonObject(postResponse.body().asString()).mapTo(EventDescriptor.class);
   }
 

--- a/mod-pubsub-server/src/test/java/org/folio/rest/impl/MessagingModulesApiTest.java
+++ b/mod-pubsub-server/src/test/java/org/folio/rest/impl/MessagingModulesApiTest.java
@@ -9,7 +9,6 @@ import org.folio.rest.jaxrs.model.EventDescriptor;
 import org.folio.rest.jaxrs.model.PublisherDescriptor;
 import org.folio.rest.jaxrs.model.SubscriberDescriptor;
 import org.folio.rest.jaxrs.model.SubscriptionDefinition;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -18,6 +17,7 @@ import java.util.Collections;
 
 import static org.folio.rest.jaxrs.model.MessagingModule.ModuleRole.PUBLISHER;
 import static org.folio.rest.jaxrs.model.MessagingModule.ModuleRole.SUBSCRIBER;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
 @RunWith(VertxUnitRunner.class)
@@ -143,7 +143,7 @@ public class MessagingModulesApiTest extends AbstractRestTest {
       .body(JsonObject.mapFrom(eventDescriptor).encode())
       .when()
       .post(EVENT_TYPES_PATH);
-    Assert.assertThat(postResponse.statusCode(), is(HttpStatus.SC_CREATED));
+    assertThat(postResponse.statusCode(), is(HttpStatus.SC_CREATED));
     return new JsonObject(postResponse.body().asString()).mapTo(EventDescriptor.class);
   }
 }

--- a/mod-pubsub-server/src/test/java/org/folio/rest/impl/ModTenantApiTest.java
+++ b/mod-pubsub-server/src/test/java/org/folio/rest/impl/ModTenantApiTest.java
@@ -7,13 +7,13 @@ import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.okJson;
 import static com.github.tomakehurst.wiremock.client.WireMock.put;
 import static org.folio.rest.util.OkapiConnectionParams.OKAPI_URL_HEADER;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.util.UUID;
 
 import org.folio.representation.User;
 import org.folio.rest.jaxrs.model.TenantAttributes;
-import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -73,8 +73,8 @@ public class ModTenantApiTest extends AbstractRestTest {
       .when().get(TENANT_URL + "/" + id + "?wait=60000")
       .then().statusCode(200)
       .extract().body().asString();
-    Assert.assertTrue(body, new JsonObject(body).getBoolean("complete"));
-    Assert.assertEquals("Unable to update the pub-sub user: " + expectedErrorMessage,
+    assertTrue(body, new JsonObject(body).getBoolean("complete"));
+    assertEquals("Unable to update the pub-sub user: " + expectedErrorMessage,
       new JsonObject(body).getString("error"));
   }
 

--- a/mod-pubsub-server/src/test/java/org/folio/rest/impl/PublishTest.java
+++ b/mod-pubsub-server/src/test/java/org/folio/rest/impl/PublishTest.java
@@ -10,13 +10,13 @@ import org.folio.rest.jaxrs.model.PublisherDescriptor;
 import org.folio.rest.jaxrs.model.SubscriberDescriptor;
 import org.folio.rest.jaxrs.model.SubscriptionDefinition;
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import java.util.Collections;
 import java.util.UUID;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
 @RunWith(VertxUnitRunner.class)
@@ -101,7 +101,7 @@ public class PublishTest extends AbstractRestTest {
       .body(JsonObject.mapFrom(publisherDescriptor).encode())
       .when()
       .post(EVENT_TYPES_PATH + DECLARE_PUBLISHER_PATH);
-    Assert.assertThat(postResponse.statusCode(), is(HttpStatus.SC_CREATED));
+    assertThat(postResponse.statusCode(), is(HttpStatus.SC_CREATED));
   }
 
   private EventDescriptor postEventDescriptor(EventDescriptor eventDescriptor) {
@@ -110,7 +110,7 @@ public class PublishTest extends AbstractRestTest {
       .body(JsonObject.mapFrom(eventDescriptor).encode())
       .when()
       .post(EVENT_TYPES_PATH);
-    Assert.assertThat(postResponse.statusCode(), is(HttpStatus.SC_CREATED));
+    assertThat(postResponse.statusCode(), is(HttpStatus.SC_CREATED));
     return new JsonObject(postResponse.body().asString()).mapTo(EventDescriptor.class);
   }
 
@@ -127,7 +127,7 @@ public class PublishTest extends AbstractRestTest {
       .body(JsonObject.mapFrom(subscriberDescriptor).encode())
       .when()
       .post(EVENT_TYPES_PATH + DECLARE_SUBSCRIBER_PATH);
-    Assert.assertThat(postResponse.statusCode(), is(HttpStatus.SC_CREATED));
+    assertThat(postResponse.statusCode(), is(HttpStatus.SC_CREATED));
   }
 
   @After

--- a/mod-pubsub-server/src/test/java/org/folio/rest/impl/PublishersApiTest.java
+++ b/mod-pubsub-server/src/test/java/org/folio/rest/impl/PublishersApiTest.java
@@ -7,13 +7,13 @@ import io.vertx.ext.unit.junit.VertxUnitRunner;
 import org.apache.http.HttpStatus;
 import org.folio.rest.jaxrs.model.EventDescriptor;
 import org.folio.rest.jaxrs.model.PublisherDescriptor;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import java.util.Arrays;
 import java.util.Collections;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 
@@ -281,7 +281,7 @@ public class PublishersApiTest extends AbstractRestTest {
       .body(JsonObject.mapFrom(publisherDescriptor).encode())
       .when()
       .post(EVENT_TYPES_PATH + DECLARE_PUBLISHER_PATH);
-    Assert.assertThat(postResponse.statusCode(), is(HttpStatus.SC_CREATED));
+    assertThat(postResponse.statusCode(), is(HttpStatus.SC_CREATED));
   }
 
   private EventDescriptor postEventDescriptor(EventDescriptor eventDescriptor) {
@@ -290,7 +290,7 @@ public class PublishersApiTest extends AbstractRestTest {
       .body(JsonObject.mapFrom(eventDescriptor).encode())
       .when()
       .post(EVENT_TYPES_PATH);
-    Assert.assertThat(postResponse.statusCode(), is(HttpStatus.SC_CREATED));
+    assertThat(postResponse.statusCode(), is(HttpStatus.SC_CREATED));
     return new JsonObject(postResponse.body().asString()).mapTo(EventDescriptor.class);
   }
 }

--- a/mod-pubsub-server/src/test/java/org/folio/rest/impl/SubscribersApiTest.java
+++ b/mod-pubsub-server/src/test/java/org/folio/rest/impl/SubscribersApiTest.java
@@ -10,15 +10,14 @@ import org.apache.http.HttpStatus;
 import org.folio.rest.jaxrs.model.EventDescriptor;
 import org.folio.rest.jaxrs.model.SubscriberDescriptor;
 import org.folio.rest.jaxrs.model.SubscriptionDefinition;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import java.util.Arrays;
 import java.util.Collections;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.notNullValue;
 
 @RunWith(VertxUnitRunner.class)
 public class SubscribersApiTest extends AbstractRestTest {
@@ -276,7 +275,7 @@ public class SubscribersApiTest extends AbstractRestTest {
       .body(JsonObject.mapFrom(subscriberDescriptor).encode())
       .when()
       .post(EVENT_TYPES_PATH + DECLARE_SUBSCRIBER_PATH);
-    Assert.assertThat(postResponse.statusCode(), is(HttpStatus.SC_CREATED));
+    assertThat(postResponse.statusCode(), is(HttpStatus.SC_CREATED));
     async.complete();
   }
 
@@ -286,7 +285,7 @@ public class SubscribersApiTest extends AbstractRestTest {
       .body(JsonObject.mapFrom(eventDescriptor).encode())
       .when()
       .post(EVENT_TYPES_PATH);
-    Assert.assertThat(postResponse.statusCode(), is(HttpStatus.SC_CREATED));
+    assertThat(postResponse.statusCode(), is(HttpStatus.SC_CREATED));
     return new JsonObject(postResponse.body().asString()).mapTo(EventDescriptor.class);
   }
 }

--- a/mod-pubsub-server/src/test/java/org/folio/services/impl/ConsumerServiceUnitTest.java
+++ b/mod-pubsub-server/src/test/java/org/folio/services/impl/ConsumerServiceUnitTest.java
@@ -20,7 +20,6 @@ import org.folio.rest.util.OkapiConnectionParams;
 import org.folio.rest.util.RestUtil;
 import org.folio.services.SecurityManager;
 import org.folio.services.cache.Cache;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -40,6 +39,7 @@ import java.util.UUID;
 import static org.folio.rest.util.OkapiConnectionParams.OKAPI_TENANT_HEADER;
 import static org.folio.rest.util.OkapiConnectionParams.OKAPI_TOKEN_HEADER;
 import static org.folio.rest.util.OkapiConnectionParams.OKAPI_URL_HEADER;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -107,9 +107,9 @@ public class ConsumerServiceUnitTest {
     future.onComplete(ar -> {
       assertTrue(ar.succeeded());
       List<LoggedRequest> requests = WireMock.findAll(RequestPatternBuilder.allRequests());
-      Assert.assertEquals(1, requests.size());
-      Assert.assertEquals(CALLBACK_ADDRESS, requests.get(0).getUrl());
-      Assert.assertEquals("POST", requests.get(0).getMethod().getName());
+      assertEquals(1, requests.size());
+      assertEquals(CALLBACK_ADDRESS, requests.get(0).getUrl());
+      assertEquals("POST", requests.get(0).getMethod().getName());
       async.complete();
     });
   }
@@ -137,10 +137,10 @@ public class ConsumerServiceUnitTest {
     future.onComplete(ar -> {
       assertTrue(ar.succeeded());
       List<LoggedRequest> requests = WireMock.findAll(RequestPatternBuilder.allRequests());
-      Assert.assertEquals(1, requests.size());
-      Assert.assertEquals(CALLBACK_ADDRESS, requests.get(0).getUrl());
-      Assert.assertEquals("POST", requests.get(0).getMethod().getName());
-      Assert.assertEquals(event.getEventPayload(), requests.get(0).getBodyAsString());
+      assertEquals(1, requests.size());
+      assertEquals(CALLBACK_ADDRESS, requests.get(0).getUrl());
+      assertEquals("POST", requests.get(0).getMethod().getName());
+      assertEquals(event.getEventPayload(), requests.get(0).getBodyAsString());
       async.complete();
     });
   }
@@ -166,7 +166,7 @@ public class ConsumerServiceUnitTest {
     future.onComplete(ar -> {
       assertTrue(ar.succeeded());
       List<LoggedRequest> requests = WireMock.findAll(RequestPatternBuilder.allRequests());
-      Assert.assertEquals(0, requests.size());
+      assertEquals(0, requests.size());
       async.complete();
     });
   }


### PR DESCRIPTION

## Purpose
Module registration in mod-pubsub fails when MessagingDescriptor contains no publications.

Steps to Reproduce:

- Pick a module that performs registration in mod-pubsub when its TenantAPI is called
- Prepare a MessagingDescriptor with some subscriptions and no publications
- Call module's TenantAPI

## Approach
Complete future in any case