### PR TITLE
MODINV-373: Ensure exactly once processing for interaction via Kafka.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,5 @@
 ## xxxx-xx-xx v2.1.0-SNAPSHOT
+* [MODINV-373](https://issues.folio.org/browse/MODINV-373) Ensure exactly once processing for interaction via Kafka.
 
 ## 2021-03-06 v2.0.1
 * [MODPUBSUB-152](https://issues.folio.org/browse/MODPUBSUB-152) Module registration in mod-pubsub fails when MessagingDescriptor contains no publications

--- a/folio-kafka-wrapper/pom.xml
+++ b/folio-kafka-wrapper/pom.xml
@@ -52,6 +52,11 @@
       <version>2.13.3</version>
       <scope>compile</scope>
     </dependency>
+    <dependency>
+      <groupId>io.kcache</groupId>
+      <artifactId>kcache</artifactId>
+      <version>3.4.3</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/folio-kafka-wrapper/src/main/java/org/folio/kafka/KafkaConfig.java
+++ b/folio-kafka-wrapper/src/main/java/org/folio/kafka/KafkaConfig.java
@@ -1,5 +1,6 @@
 package org.folio.kafka;
 
+import io.kcache.KafkaCacheConfig;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.ToString;
@@ -8,6 +9,7 @@ import org.apache.kafka.clients.producer.ProducerConfig;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Properties;
 
 @Getter
 @Builder
@@ -27,6 +29,8 @@ public class KafkaConfig {
 
   public static final String KAFKA_CONSUMER_MAX_POLL_INTERVAL_MS_CONFIG = "kafka.consumer.max.poll.interval.ms";
   public static final String KAFKA_CONSUMER_MAX_POLL_INTERVAL_MS_CONFIG_DEFAULT = "300000";
+
+  private static final String KAFKA_CACHE_TOPIC_PROPERTY = "kafkacache.topic";
 
   private final String kafkaHost;
   private final String kafkaPort;
@@ -54,6 +58,13 @@ public class KafkaConfig {
     consumerProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.StringDeserializer");
     consumerProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.StringDeserializer");
     return consumerProps;
+  }
+
+  public KafkaCacheConfig getCacheConfig() {
+    Properties props = new Properties();
+    props.put(KafkaCacheConfig.KAFKACACHE_BOOTSTRAP_SERVERS_CONFIG, getKafkaUrl());
+    props.put(KAFKA_CACHE_TOPIC_PROPERTY, "events_cache");
+    return new KafkaCacheConfig(props);
   }
 
   public String getKafkaUrl() {

--- a/folio-kafka-wrapper/src/main/java/org/folio/kafka/cache/KafkaInternalCache.java
+++ b/folio-kafka-wrapper/src/main/java/org/folio/kafka/cache/KafkaInternalCache.java
@@ -86,6 +86,5 @@ public class KafkaInternalCache {
     }
 
     outdatedEvents.forEach(outdatedEvent -> kafkaCache.remove(outdatedEvent));
-    outdatedEvents.clear();
   }
 }

--- a/folio-kafka-wrapper/src/main/java/org/folio/kafka/cache/KafkaInternalCache.java
+++ b/folio-kafka-wrapper/src/main/java/org/folio/kafka/cache/KafkaInternalCache.java
@@ -1,0 +1,91 @@
+package org.folio.kafka.cache;
+
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.folio.kafka.KafkaConfig;
+
+import io.kcache.Cache;
+import io.kcache.KafkaCache;
+import io.kcache.KeyValueIterator;
+import lombok.Builder;
+
+/**
+ * Cache in Kafka for processing events.
+ */
+public class KafkaInternalCache {
+
+  private static final Logger LOGGER = LogManager.getLogger(KafkaInternalCache.class);
+
+  private final KafkaConfig kafkaConfig;
+  private Cache<String, String> kafkaCache;
+
+  @Builder
+  private KafkaInternalCache(KafkaConfig kafkaConfig) {
+    this.kafkaConfig = kafkaConfig;
+  }
+
+  /**
+   * Initialize cache for Kafka with specific properties in KafkaConfig.
+   */
+  public void initKafkaCache() {
+    Cache<String, String> cache = new KafkaCache<>(
+      kafkaConfig.getCacheConfig(),
+      Serdes.String(),
+      Serdes.String()
+    );
+    this.kafkaCache = cache;
+    cache.init();
+  }
+
+
+  /**
+   * Put to the cache an element with specific key. Tha value - current time. Example : 2021-03-17T14:58:05.725953.
+   * Stored as Strings.
+   * @param key - key for the event. Mostly - uuid.
+   */
+  public void putToCache(String key) {
+    String currentTime = LocalDateTime.now().toString();
+    kafkaCache.put(key, currentTime);
+  }
+
+  /**
+   * Check if element in cache exists by specified key.
+   * @param key - element`s key.
+   * @return true - if cache contains element by this key. false - if not.
+   */
+  public boolean containsByKey(String key) {
+    String value = kafkaCache.get(key);
+    return value != null;
+  }
+
+  /**
+   * Clean Kafka cache from outdated elements.
+   * Outdated element - element difference between its value and current time is more or equal to the eventTimeoutHours.
+   * @param eventTimeoutHours - timeout for event in hours.
+   */
+  public void cleanupEvents(int eventTimeoutHours) {
+    List<String> outdatedEvents = new ArrayList<>();
+
+    LocalDateTime currentTime = LocalDateTime.now();
+    KeyValueIterator<String, String> events = kafkaCache.all();
+    events.forEachRemaining(currentEvent -> {
+      LocalDateTime eventTime = LocalDateTime.parse(currentEvent.value);
+      long hoursBetween = ChronoUnit.HOURS.between(eventTime, currentTime);
+      if (hoursBetween >= eventTimeoutHours) {
+        outdatedEvents.add(currentEvent.key);
+      }
+    });
+    if(!outdatedEvents.isEmpty()) {
+      LOGGER.info("Clearing cache from outdated events...");
+    }
+
+    outdatedEvents.forEach(outdatedEvent -> kafkaCache.remove(outdatedEvent));
+    outdatedEvents.clear();
+  }
+}

--- a/folio-kafka-wrapper/src/main/java/org/folio/kafka/cache/util/CacheUtil.java
+++ b/folio-kafka-wrapper/src/main/java/org/folio/kafka/cache/util/CacheUtil.java
@@ -1,0 +1,26 @@
+package org.folio.kafka.cache.util;
+
+import org.folio.kafka.cache.KafkaInternalCache;
+
+import io.vertx.core.Vertx;
+
+/**
+ * Util for Kafka cache.
+ */
+public class CacheUtil {
+
+  private CacheUtil() {
+  }
+
+  /**
+   * Set periodic task (cleanup cache from outdated events) to the vertx with specific params.
+   * @param vertx - vertx for periodic.
+   * @param kafkaInternalCache - kafka cache.
+   * @param periodicTime - time between executing periodic task.
+   * @param eventTimeoutHours - timeout for event in hours.
+   */
+  public static void initCacheCleanupPeriodicTask(Vertx vertx, KafkaInternalCache kafkaInternalCache, long periodicTime, int eventTimeoutHours) {
+    vertx.setPeriodic(periodicTime,
+      e -> vertx.<Void>executeBlocking(b -> kafkaInternalCache.cleanupEvents(eventTimeoutHours)));
+  }
+}


### PR DESCRIPTION
## Purpose
Ensure exactly once processing for interaction via Kafka.

## Approach
Added Kafka Cache for processing events for exactly-once processing. 

## Learning
More info: https://issues.folio.org/browse/MODINV-373.
Should be merged before: https://github.com/folio-org/mod-inventory/pull/319