### PR TITLE
[MODPUBSUB-158] Initialize headers map when registering subscribers after startup

### DIFF
--- a/mod-pubsub-server/src/main/java/org/folio/services/impl/StartupServiceImpl.java
+++ b/mod-pubsub-server/src/main/java/org/folio/services/impl/StartupServiceImpl.java
@@ -13,6 +13,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import java.util.Collections;
+import java.util.HashMap;
 
 import static org.folio.rest.jaxrs.model.MessagingModule.ModuleRole.SUBSCRIBER;
 
@@ -45,6 +46,7 @@ public class StartupServiceImpl implements StartupService {
           OkapiConnectionParams params = new OkapiConnectionParams(vertx);
           params.setOkapiUrl(kafkaConfig.getOkapiUrl());
           params.setTenantId(messagingModule.getTenantId());
+          params.setHeaders(new HashMap<>());
           kafkaTopicService.createTopics(Collections.singletonList(messagingModule.getEventType()), messagingModule.getTenantId())
             .compose(ar -> consumerService.subscribe(Collections.singletonList(messagingModule.getEventType()), params));
         });


### PR DESCRIPTION
## Purpose
Fix 404 returned by mod-login when trying to register existing subscribers during module initialization.

## Approach
Module's implementation of InitAPI fetches a set of existing subscribers, tries to register them as consumers of corresponding Kafka topics and creates a handler for every event type. In order to deliver a message handlers need a valid JWT-token, obtained by loging in user `pub-sub`. However, `OkapiConnectionParams` created within `StartupService#initSubscribers` and used to build a request to mod-login, do not contain any Okapi headers (the map is null), which results in the call to `/authn/login` being made without Okapi headers, most notably `x-okapi-tenant`. Okapi thinks such calls are intended for tenant `supertenant`, so it tries to call supetenant's mod-login, which does not exist, so Okapi responds with a 404:
```
INFO  DockerModuleHandle   mod-pubsub-2.1.0-SNAPSHOT.144 13:10:12 [] [] [] [] INFO  aConsumerServiceImpl Received FEE_FINE_BALANCE_CHANGED event with id '7a05ff0e-741b-46f6-a6bf-191c9e717785'
INFO  DockerModuleHandle   mod-pubsub-2.1.0-SNAPSHOT.144 13:10:13 [] [] [] [] INFO  RestUtil             Sending POST for http://10.0.2.15:9130/authn/login
INFO  ProxyContext         556648/authn RES 404 - okapi No suitable module found for path /authn/login for tenant supertenant
ERROR HttpResponse         HTTP response code=404 msg=No suitable module found for path /authn/login for tenant supertenant
INFO  DockerModuleHandle   mod-pubsub-2.1.0-SNAPSHOT.144 13:10:13 [] [] [] [] INFO  RestUtil             Response received with statusCode 404
INFO  DockerModuleHandle   mod-pubsub-2.1.0-SNAPSHOT.144 13:10:13 [] [] [] [] ERROR SecurityManagerImpl  pub-sub user was not logged in, received status 404
```

Passing an empty map instead of null forces `RestUtil#doRequest` to derive missing headers from other fields of `OkapiConnectionParams`, which fixes the problem.

Even though registration of a new subscriber by calling `POST /pubsub/event-types/{eventTypeName}/subscribers` uses the same code, it does not cause the same error because in this case Okapi headers are present. However, restarting the module will cause the error for the new subscriber as well.