### PR TITLE
[MODPUBSUB-155] fix incorrect future composition in MessagingModuleServiceImpl

### DIFF
--- a/mod-pubsub-server/src/main/java/org/folio/services/impl/MessagingModuleServiceImpl.java
+++ b/mod-pubsub-server/src/main/java/org/folio/services/impl/MessagingModuleServiceImpl.java
@@ -88,7 +88,7 @@ public class MessagingModuleServiceImpl implements MessagingModuleService {
       .collect(Collectors.toList());
 
     return eventDescriptorDao.getByEventTypes(eventTypes)
-      .map(existingDescriptorList -> {
+      .compose(existingDescriptorList -> {
         Map<String, EventDescriptor> descriptorsMap = existingDescriptorList.stream()
           .collect(Collectors.toMap(EventDescriptor::getEventType, descriptor -> descriptor));
         List<Future> futures = new ArrayList<>();


### PR DESCRIPTION
## Purpose
Fix occasional subscriber registration failures. See [MODPUBSUB-155](https://issues.folio.org/browse/MODPUBSUB-155) for details.

## Approach
Using `Future#map` instead of `Future#compose` wraps `CompositeFuture` in another `Future` and completes it immediately, without waiting until all the missing event types are created. This means that sometimes we try to create a subscriber before newly created event type makes its way into the DB, thus violating foreign key constraint:
```
{
  "message": "insert or update on table \"messaging_module\" violates foreign key constraint \"fk_event_type_id\"",
  "severity": "ERROR",
  "code": "23503",
  "detail": "Key (event_type_id)=(ITEM_CLAIMED_RETURNED) is not present in table \"event_descriptor\".",
  "file": "ri_triggers.c",
  "line": "3255",
  "routine": "ri_ReportViolation",
  "schema": "pubsub_config",
  "table": "messaging_module",
  "constraint": "fk_event_type_id"
}
```
I was able to reproduce this issue locally by repeatedly running the test `MessagingModulesApiTest#shouldDeleteSubscriberOnDeleteWhenSubscriberRoleIsSpecified` - the one that caused most of recent build failures on [Jenkins](https://jenkins-aws.indexdata.com/job/folio-org/job/mod-pubsub/job/master/). Running it with `io.vertx.ext.unit.junit.Repeat` annotation usually made it fail after few hundred iterations on my machine.

I ran multiple builds of this [branch on Jenkins](https://jenkins-aws.indexdata.com/job/folio-org/job/mod-pubsub/job/MODPUBSUB-155/) to test the fix. Compare it to [build history of `master`](https://jenkins-aws.indexdata.com/job/folio-org/job/mod-pubsub/job/master/) up until now (before build #146).