### PR TITLE
[MODPUBSUB-157] mod-circulation-storage doesn't register on pubsub upon environment startup

### DIFF
--- a/mod-pubsub-server/src/main/java/org/folio/dao/impl/MessagingModuleDaoImpl.java
+++ b/mod-pubsub-server/src/main/java/org/folio/dao/impl/MessagingModuleDaoImpl.java
@@ -158,8 +158,9 @@ public class MessagingModuleDaoImpl implements MessagingModuleDao {
       conditionBuilder.append(" AND event_type_id = '").append(filter.getEventType()).append("'");
     }
     if (filter.getModuleId() != null) {
-      conditionBuilder.append(" AND module_id ~ '").append(filter.getModuleId()
-        .replaceAll("\\d+", "\\\\d+")).append("'");
+      conditionBuilder.append(" AND module_id ~ '")
+        .append(buildRegexPatternForModuleId(filter))
+        .append("'");
     }
     if (filter.getTenantId() != null) {
       conditionBuilder.append(" AND tenant_id = '").append(filter.getTenantId()).append("'");
@@ -174,5 +175,11 @@ public class MessagingModuleDaoImpl implements MessagingModuleDao {
       conditionBuilder.append(" AND subscriber_callback = '").append(filter.getSubscriberCallback()).append("'");
     }
     return conditionBuilder.toString();
+  }
+
+  private static String buildRegexPatternForModuleId(MessagingModuleFilter filter) {
+    return filter.getModuleId()
+      .replaceAll("\\d+", "\\\\d+")
+      .replace(".", "\\."); // escape version separators to avoid matching any character
   }
 }

--- a/mod-pubsub-server/src/main/java/org/folio/dao/impl/MessagingModuleDaoImpl.java
+++ b/mod-pubsub-server/src/main/java/org/folio/dao/impl/MessagingModuleDaoImpl.java
@@ -158,8 +158,8 @@ public class MessagingModuleDaoImpl implements MessagingModuleDao {
       conditionBuilder.append(" AND event_type_id = '").append(filter.getEventType()).append("'");
     }
     if (filter.getModuleId() != null) {
-      conditionBuilder.append(" AND module_id LIKE '").append(filter.getModuleId()
-        .replaceAll("\\d", "%")).append("'");
+      conditionBuilder.append(" AND module_id ~ '").append(filter.getModuleId()
+        .replaceAll("\\d+", "\\\\d+")).append("'");
     }
     if (filter.getTenantId() != null) {
       conditionBuilder.append(" AND tenant_id = '").append(filter.getTenantId()).append("'");

--- a/mod-pubsub-server/src/main/java/org/folio/rest/impl/ModTenantAPI.java
+++ b/mod-pubsub-server/src/main/java/org/folio/rest/impl/ModTenantAPI.java
@@ -29,7 +29,8 @@ public class ModTenantAPI extends TenantAPI {
         Vertx vertx = context.owner();
         LiquibaseUtil.initializeSchemaForTenant(vertx, tenantId);
         OkapiConnectionParams params = new OkapiConnectionParams(headers, vertx);
-        return securityManager.createPubSubUser(params).map(num);
+        return securityManager.createPubSubUser(params)
+          .compose(ar -> securityManager.loginPubSubUser(params)).map(num);
       });
   }
 }

--- a/mod-pubsub-server/src/main/java/org/folio/rest/impl/ModTenantAPI.java
+++ b/mod-pubsub-server/src/main/java/org/folio/rest/impl/ModTenantAPI.java
@@ -1,20 +1,15 @@
 package org.folio.rest.impl;
 
-import io.vertx.core.AsyncResult;
 import io.vertx.core.Context;
 import io.vertx.core.Future;
-import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import org.folio.liquibase.LiquibaseUtil;
-import org.folio.rest.RestVerticle;
-import org.folio.rest.annotations.Validate;
 import org.folio.rest.jaxrs.model.TenantAttributes;
 import org.folio.rest.util.OkapiConnectionParams;
 import org.folio.services.SecurityManager;
 import org.folio.spring.SpringContextUtil;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import javax.ws.rs.core.Response;
 import java.util.Map;
 
 public class ModTenantAPI extends TenantAPI {
@@ -34,8 +29,7 @@ public class ModTenantAPI extends TenantAPI {
         Vertx vertx = context.owner();
         LiquibaseUtil.initializeSchemaForTenant(vertx, tenantId);
         OkapiConnectionParams params = new OkapiConnectionParams(headers, vertx);
-        return securityManager.createPubSubUser(params)
-          .compose(ar -> securityManager.loginPubSubUser(params)).map(num);
+        return securityManager.createPubSubUser(params).map(num);
       });
   }
 }


### PR DESCRIPTION
## Purpose
Fix mod-circulation-storage's failure to register as publisher of `LOG_RECORD` events upon enviroment startup.

## Approach
Before registering a new event publisher, mod-pubsub finds and deletes all existing publisher definitions with the same event type, module role, tenant ID and module name. In order to perform this search when registering mod-circulation as publisher of `LOG_RECORD` events, a query with  the following WHERE clause is used:

```
WHERE TRUE AND module_id LIKE 'mod-circulation-%%.%.%' AND tenant_id = 'diku' AND role = 'PUBLISHER';
```

Unfortunately, pattern `'mod-circulation-%%.%.%'` also matches `mod-circulation-storage-...`, so existing publisher definitions for this module are deleted as well. Since during environment startup mod-circulation-storage is launched first, its registration as publisher of `LOG_RECORD` events is revoked by subsequent mod-circulation's registration as publisher of the same event type.

The simplest solution is to use more precise regex-based filtering. In this case - wildcards which match numbers only. With proposed change, the abovementioned query will look as follows:

```
WHERE TRUE AND module_id ~ 'mod-circulation-\d+\.\d+\.\d+' AND tenant_id = 'diku' AND role = 'PUBLISHER';
```
