### PR TITLE
MODPUBSUB-163 - Kafka Thread Blocked Timeout (KCache)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,7 @@
-## xxxx-xx-xx v2.1.0-SNAPSHOT
+## xxxx-xx-xx v2.0.5-SNAPSHOT
+* [MODPUBSUB-163](https://issues.folio.org/browse/MODPUBSUB-163) Kafka Thread Blocked Timeout (KCache)
+
+## 2021-03-25 v2.0.2-SNAPSHOT
 * [MODINV-373](https://issues.folio.org/browse/MODINV-373) Ensure exactly once processing for interaction via Kafka.
 * [MODDATAIMP-372](https://issues.folio.org/browse/MODDATAIMP-372) Data Import job creates SRS records but not all expected Inventory records
 

--- a/folio-kafka-wrapper/pom.xml
+++ b/folio-kafka-wrapper/pom.xml
@@ -57,6 +57,18 @@
       <artifactId>kcache</artifactId>
       <version>3.4.3</version>
     </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>${junit.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>net.mguenther.kafka</groupId>
+      <artifactId>kafka-junit</artifactId>
+      <version>2.6.0</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/folio-kafka-wrapper/src/main/java/org/folio/kafka/KafkaConfig.java
+++ b/folio-kafka-wrapper/src/main/java/org/folio/kafka/KafkaConfig.java
@@ -33,6 +33,7 @@ public class KafkaConfig {
   public static final String KAFKA_CONSUMER_MAX_POLL_INTERVAL_MS_CONFIG_DEFAULT = "300000";
 
   private static final String KAFKA_CACHE_TOPIC_PROPERTY = "kafkacache.topic";
+  private static final String KAFKA_CACHE_TOPIC_PROPERTY_DEFAULT = "events_cache";
 
   private final String kafkaHost;
   private final String kafkaPort;
@@ -65,7 +66,7 @@ public class KafkaConfig {
   public KafkaCacheConfig getCacheConfig() {
     Properties props = new Properties();
     props.put(KafkaCacheConfig.KAFKACACHE_BOOTSTRAP_SERVERS_CONFIG, "PLAINTEXT://" + getKafkaUrl()); //It should be as PLAINTEXT, as known issue in Kafka.
-    props.put(KAFKA_CACHE_TOPIC_PROPERTY, "events_cache");
+    props.put(KAFKA_CACHE_TOPIC_PROPERTY, SimpleConfigurationReader.getValue(KAFKA_CACHE_TOPIC_PROPERTY, KAFKA_CACHE_TOPIC_PROPERTY_DEFAULT));
     props.put(KAFKACACHE_TOPIC_REQUIRE_COMPACT_CONFIG, false);
     return new KafkaCacheConfig(props);
   }

--- a/folio-kafka-wrapper/src/main/java/org/folio/kafka/KafkaConfig.java
+++ b/folio-kafka-wrapper/src/main/java/org/folio/kafka/KafkaConfig.java
@@ -11,6 +11,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 
+import static io.kcache.KafkaCacheConfig.KAFKACACHE_TOPIC_REQUIRE_COMPACT_CONFIG;
+
 @Getter
 @Builder
 @ToString
@@ -64,6 +66,7 @@ public class KafkaConfig {
     Properties props = new Properties();
     props.put(KafkaCacheConfig.KAFKACACHE_BOOTSTRAP_SERVERS_CONFIG, "PLAINTEXT://" + getKafkaUrl()); //It should be as PLAINTEXT, as known issue in Kafka.
     props.put(KAFKA_CACHE_TOPIC_PROPERTY, "events_cache");
+    props.put(KAFKACACHE_TOPIC_REQUIRE_COMPACT_CONFIG, false);
     return new KafkaCacheConfig(props);
   }
 

--- a/folio-kafka-wrapper/src/main/java/org/folio/kafka/cache/KafkaInternalCache.java
+++ b/folio-kafka-wrapper/src/main/java/org/folio/kafka/cache/KafkaInternalCache.java
@@ -38,7 +38,7 @@ public class KafkaInternalCache {
   public static final String KAFKA_CACHE_NUMBER_OF_PARTITIONS = "kafkacache.topic.number.partitions";
   public static final String KAFKA_CACHE_NUMBER_OF_PARTITIONS_DEFAULT = "1";
   public static final String KAFKA_CACHE_REPLICATION_FACTOR = "kafkacache.topic.replication.factor";
-  public static final String KAFKA_CACHE_REPLICATION_FACTOR_DEFAULT = "3";
+  public static final String KAFKA_CACHE_REPLICATION_FACTOR_DEFAULT = "1";
 
   private static final Logger LOGGER = LogManager.getLogger(KafkaInternalCache.class);
 

--- a/folio-kafka-wrapper/src/main/java/org/folio/kafka/cache/KafkaInternalCache.java
+++ b/folio-kafka-wrapper/src/main/java/org/folio/kafka/cache/KafkaInternalCache.java
@@ -82,9 +82,13 @@ public class KafkaInternalCache {
         LOGGER.info("Kafka cache topic has been successfully created: {}", topicRequest);
       }
     } catch (TimeoutException e) {
-      LOGGER.error("Timed out trying to create Kafka cache topic '{}'", cacheTopic, e);
+      throw new KafkaInternalCacheInitializationException(format("Timed out trying to create Kafka cache topic '%s'", cacheTopic), e);
     } catch (InterruptedException | ExecutionException e) {
-      LOGGER.error("Failed to create Kafka cache topic '{}'", cacheTopic, e);
+      if (e.getCause() instanceof TopicExistsException) {
+        LOGGER.info("Kafka cache topic '{}' has not been created, it's already exists", cacheTopic);
+      } else {
+        throw new KafkaInternalCacheInitializationException(format("Failed to create Kafka cache topic '%s'", cacheTopic), e);
+      }
     }
   }
 

--- a/folio-kafka-wrapper/src/main/java/org/folio/kafka/cache/KafkaInternalCache.java
+++ b/folio-kafka-wrapper/src/main/java/org/folio/kafka/cache/KafkaInternalCache.java
@@ -127,10 +127,12 @@ public class KafkaInternalCache {
     LocalDateTime currentTime = LocalDateTime.now();
     KeyValueIterator<String, String> events = kafkaCache.all();
     events.forEachRemaining(currentEvent -> {
-      LocalDateTime eventTime = LocalDateTime.parse(currentEvent.value);
-      long hoursBetween = ChronoUnit.HOURS.between(eventTime, currentTime);
-      if (hoursBetween >= eventTimeoutHours) {
-        outdatedEvents.add(currentEvent.key);
+      if (currentEvent.value != null) {
+        LocalDateTime eventTime = LocalDateTime.parse(currentEvent.value);
+        long hoursBetween = ChronoUnit.HOURS.between(eventTime, currentTime);
+        if (hoursBetween >= eventTimeoutHours) {
+          outdatedEvents.add(currentEvent.key);
+        }
       }
     });
     if (!outdatedEvents.isEmpty()) {

--- a/folio-kafka-wrapper/src/main/java/org/folio/kafka/cache/exceptions/KafkaInternalCacheInitializationException.java
+++ b/folio-kafka-wrapper/src/main/java/org/folio/kafka/cache/exceptions/KafkaInternalCacheInitializationException.java
@@ -1,0 +1,8 @@
+package org.folio.kafka.cache.exceptions;
+
+public class KafkaInternalCacheInitializationException extends RuntimeException{
+
+  public KafkaInternalCacheInitializationException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/folio-kafka-wrapper/src/test/java/org/folio/kafka/cache/KafkaInternalCacheTest.java
+++ b/folio-kafka-wrapper/src/test/java/org/folio/kafka/cache/KafkaInternalCacheTest.java
@@ -1,0 +1,70 @@
+package org.folio.kafka.cache;
+
+import net.mguenther.kafka.junit.EmbeddedKafkaCluster;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.apache.kafka.clients.admin.TopicDescription;
+import org.folio.kafka.KafkaConfig;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static net.mguenther.kafka.junit.EmbeddedKafkaCluster.provisionWith;
+import static net.mguenther.kafka.junit.EmbeddedKafkaClusterConfig.useDefaults;
+import static org.apache.kafka.common.config.TopicConfig.CLEANUP_POLICY_CONFIG;
+import static org.apache.kafka.common.config.TopicConfig.CLEANUP_POLICY_DELETE;
+import static org.junit.Assert.assertEquals;
+
+public class KafkaInternalCacheTest {
+
+  public static final String CACHE_TOPIC = "events_cache";
+
+  @ClassRule
+  public static EmbeddedKafkaCluster kafkaCluster = provisionWith(useDefaults());
+
+  private static KafkaConfig kafkaConfig;
+  private static AdminClient adminClient;
+
+  @BeforeClass
+  public static void setUpClass() {
+    String[] hostAndPort = kafkaCluster.getBrokerList().split(":");
+    kafkaConfig = KafkaConfig.builder()
+      .kafkaHost(hostAndPort[0])
+      .kafkaPort(hostAndPort[1])
+      .build();
+
+    adminClient = AdminClient.create(Map.of(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaConfig.getKafkaUrl()));
+  }
+
+  @Test
+  public void shouldCreateCacheTopicOnCacheInit() throws ExecutionException, TimeoutException, InterruptedException {
+    // given
+    KafkaInternalCache kafkaInternalCache = KafkaInternalCache.builder()
+      .kafkaConfig(kafkaConfig)
+      .build();
+
+    // when
+    kafkaInternalCache.initKafkaCache();
+
+    //then
+    kafkaCluster.exists(CACHE_TOPIC);
+    Properties topicConfig = kafkaCluster.fetchTopicConfig(CACHE_TOPIC);
+    assertEquals(topicConfig.getProperty(CLEANUP_POLICY_CONFIG), CLEANUP_POLICY_DELETE);
+
+    Map<String, TopicDescription> topicDescriptionMap = adminClient.describeTopics(Collections.singleton(CACHE_TOPIC)).all().get(60, TimeUnit.SECONDS);
+    TopicDescription topicDescription = topicDescriptionMap.get(CACHE_TOPIC);
+    assertEquals(1, topicDescription.partitions().size());
+    assertEquals(1, topicDescription.partitions().get(0).replicas().size());
+  }
+
+  public void teardown() {
+    adminClient.close();
+  }
+}

--- a/folio-kafka-wrapper/src/test/java/org/folio/kafka/cache/KafkaInternalCacheTest.java
+++ b/folio-kafka-wrapper/src/test/java/org/folio/kafka/cache/KafkaInternalCacheTest.java
@@ -5,6 +5,7 @@ import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.clients.admin.TopicDescription;
 import org.folio.kafka.KafkaConfig;
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -64,7 +65,8 @@ public class KafkaInternalCacheTest {
     assertEquals(1, topicDescription.partitions().get(0).replicas().size());
   }
 
-  public void teardown() {
+  @AfterClass
+  public static void teardown() {
     adminClient.close();
   }
 }

--- a/folio-kafka-wrapper/src/test/java/org/folio/kafka/cache/KafkaInternalCacheTest.java
+++ b/folio-kafka-wrapper/src/test/java/org/folio/kafka/cache/KafkaInternalCacheTest.java
@@ -21,6 +21,8 @@ import static net.mguenther.kafka.junit.EmbeddedKafkaCluster.provisionWith;
 import static net.mguenther.kafka.junit.EmbeddedKafkaClusterConfig.useDefaults;
 import static org.apache.kafka.common.config.TopicConfig.CLEANUP_POLICY_CONFIG;
 import static org.apache.kafka.common.config.TopicConfig.CLEANUP_POLICY_DELETE;
+import static org.apache.kafka.common.config.TopicConfig.RETENTION_MS_CONFIG;
+import static org.folio.kafka.cache.KafkaInternalCache.KAFKA_CACHE_RETENTION_MS_DEFAULT;
 import static org.junit.Assert.assertEquals;
 
 public class KafkaInternalCacheTest {
@@ -58,6 +60,7 @@ public class KafkaInternalCacheTest {
     kafkaCluster.exists(CACHE_TOPIC);
     Properties topicConfig = kafkaCluster.fetchTopicConfig(CACHE_TOPIC);
     assertEquals(topicConfig.getProperty(CLEANUP_POLICY_CONFIG), CLEANUP_POLICY_DELETE);
+    assertEquals(topicConfig.getProperty(RETENTION_MS_CONFIG), KAFKA_CACHE_RETENTION_MS_DEFAULT);
 
     Map<String, TopicDescription> topicDescriptionMap = adminClient.describeTopics(Collections.singleton(CACHE_TOPIC)).all().get(60, TimeUnit.SECONDS);
     TopicDescription topicDescription = topicDescriptionMap.get(CACHE_TOPIC);


### PR DESCRIPTION
## Approach
* expanded KafkaInternalCache with logic for topic creation with topic cleanup policy `delete`
* set kafkacache.topic.require.compact = false into the kafkacache config to avoid validation for `cleanup.policy = compact`


## Learning
[MODINV-396](https://issues.folio.org/browse/MODINV-396)