### PR TITLE
[MODPUBSUB-166] Close HttpClient after use in PubSubClientUtils

### DIFF
--- a/mod-pubsub-client/src/main/java/org/folio/rest/client/PubsubClient.java
+++ b/mod-pubsub-client/src/main/java/org/folio/rest/client/PubsubClient.java
@@ -7,6 +7,9 @@ import io.vertx.core.buffer.Buffer;
 import io.vertx.ext.web.client.HttpResponse;
 import io.vertx.ext.web.client.WebClient;
 import io.vertx.ext.web.client.WebClientOptions;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.folio.rest.tools.utils.VertxUtils;
 
 import java.io.UnsupportedEncodingException;
@@ -17,6 +20,8 @@ import java.net.URLEncoder;
  * Auto-generated code - based on class org.folio.rest.jaxrs.resource.Pubsub
  */
 public class PubsubClient {
+
+  private static final Logger LOGGER = LogManager.getLogger();
 
   private final String tenantId;
   private final String token;
@@ -500,6 +505,18 @@ public class PubsubClient {
       request.putHeader("X-Okapi-Url", okapiUrl);
     }
     request.sendBuffer(buffer, responseHandler);
+  }
+
+  /**
+   * Close the client. Closing will close down any pooled connections.
+   * Clients should always be closed after use.
+   */
+  public void close() {
+    try {
+      httpClient.close();
+    } catch (Exception e) {
+      LOGGER.error("Error closing HTTP client", e);
+    }
   }
 
 }

--- a/mod-pubsub-client/src/main/java/org/folio/util/pubsub/PubSubClientUtils.java
+++ b/mod-pubsub-client/src/main/java/org/folio/util/pubsub/PubSubClientUtils.java
@@ -75,7 +75,7 @@ public class PubSubClientUtils {
       LOGGER.error("Error during sending event message to PubSub", e);
       result.completeExceptionally(e);
     }
-    return result;
+    return result.whenComplete((res, throwable) -> client.close());
   }
 
   /**
@@ -105,7 +105,7 @@ public class PubSubClientUtils {
       LOGGER.error("Error during registration module in PubSub", e);
       result = CompletableFuture.failedFuture(e);
     }
-    return result;
+    return result.whenComplete((res, throwable) -> client.close());
   }
 
   private static CompletableFuture<Void> registerEventTypes(PubsubClient client, List<EventDescriptor> events) {
@@ -186,7 +186,8 @@ public class PubSubClientUtils {
     String moduleId = constructModuleName();
 
     return unregisterModuleByIdAndRole(client, moduleId, PUBLISHER)
-      .thenCompose(ar -> unregisterModuleByIdAndRole(client, moduleId, SUBSCRIBER));
+      .thenCompose(ar -> unregisterModuleByIdAndRole(client, moduleId, SUBSCRIBER))
+      .whenComplete((ar, e) -> client.close());
   }
 
   private static CompletableFuture<Boolean> unregisterModuleByIdAndRole(PubsubClient client, String moduleId, MessagingModule.ModuleRole moduleRole) {


### PR DESCRIPTION
## Purpose
Close HttpClient explicitly in `PubSubClientUtils` to avoid memory leak.
Resolves [MODPUBSUB-166](https://issues.folio.org/browse/MODPUBSUB-166).
Prerequisite for [CIRC-1121](https://issues.folio.org/browse/CIRC-1121).

## Approach
Bring back explicit closure of `PubsubClient` introduced in #109 but removed in #126.

Results of mod-circulation's heap dump analysis after 1000 checkins:

**BEFORE**

![before](https://user-images.githubusercontent.com/56632770/117275363-a3076480-ae66-11eb-9d0e-07deaf28906a.png)

**AFTER**

![after](https://user-images.githubusercontent.com/56632770/117275437-b4e90780-ae66-11eb-9baa-14557c4d254e.png)

