### PR TITLE
MODPUBSUB-171 - Provide properties for Kafka security in kafka-wrapper

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,5 @@
 ## XXXX-XX-XX 2.1.0-SNAPSHOT
+* [MODPUBSUB-171](https://issues.folio.org/browse/MODPUBSUB-171) Provide properties for Kafka security in kafka-wrapper
 
 ## 2021-04-22 v2.0.5
 * [MODPUBSUB-163](https://issues.folio.org/browse/MODPUBSUB-163) Kafka Thread Blocked Timeout (KCache)

--- a/folio-kafka-wrapper/src/main/java/org/folio/kafka/KafkaConfig.java
+++ b/folio-kafka-wrapper/src/main/java/org/folio/kafka/KafkaConfig.java
@@ -10,6 +10,7 @@ import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.config.SslConfigs;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
@@ -34,26 +35,26 @@ public class KafkaConfig {
   public static final String KAFKA_CONSUMER_MAX_POLL_INTERVAL_MS_CONFIG = "kafka.consumer.max.poll.interval.ms";
   public static final String KAFKA_CONSUMER_MAX_POLL_INTERVAL_MS_CONFIG_DEFAULT = "300000";
 
-  public static final String KAFKA_SECURITY_PROTOCOL = "security.protocol";
+  public static final String KAFKA_SECURITY_PROTOCOL_CONFIG = "security.protocol";
   public static final String KAFKA_SECURITY_PROTOCOL_DEFAULT = "PLAINTEXT";
 
-  public static final String KAFKA_SSL_PROTOCOL = "ssl.protocol";
+  public static final String KAFKA_SSL_PROTOCOL_CONFIG = "ssl.protocol";
   public static final String KAFKA_SSL_PROTOCOL_DEFAULT = "TLSv1.2";
 
-  public static final String KAFKA_SSL_KEY_PASSWORD = "ssl.key.password";
+  public static final String KAFKA_SSL_KEY_PASSWORD_CONFIG = "ssl.key.password";
 
-  public static final String KAFKA_SSL_TRUSTSTORE_LOCATION = "ssl.truststore.location";
+  public static final String KAFKA_SSL_TRUSTSTORE_LOCATION_CONFIG = "ssl.truststore.location";
 
-  public static final String KAFKA_SSL_TRUSTSTORE_PASSWORD = "ssl.truststore.password";
+  public static final String KAFKA_SSL_TRUSTSTORE_PASSWORD_CONFIG = "ssl.truststore.password";
 
-  public static final String KAFKA_SSL_TRUSTSTORE_TYPE = "ssl.truststore.type";
+  public static final String KAFKA_SSL_TRUSTSTORE_TYPE_CONFIG = "ssl.truststore.type";
   public static final String KAFKA_SSL_TRUSTSTORE_TYPE_DEFAULT = "JKS";
 
-  public static final String KAFKA_SSL_KEYSTORE_LOCATION = "ssl.keystore.location";
+  public static final String KAFKA_SSL_KEYSTORE_LOCATION_CONFIG = "ssl.keystore.location";
 
-  public static final String KAFKA_SSL_KEYSTORE_PASSWORD = "ssl.keystore.password";
+  public static final String KAFKA_SSL_KEYSTORE_PASSWORD_CONFIG = "ssl.keystore.password";
 
-  public static final String KAFKA_SSL_KEYSTORE_TYPE = "ssl.keystore.type";
+  public static final String KAFKA_SSL_KEYSTORE_TYPE_CONFIG = "ssl.keystore.type";
   public static final String KAFKA_SSL_KEYSTORE_TYPE_DEFAULT = "JKS";
 
   private static final String KAFKA_CACHE_TOPIC_PROPERTY = "kafkacache.topic";
@@ -72,15 +73,24 @@ public class KafkaConfig {
     producerProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.StringSerializer");
     producerProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.StringSerializer");
 
-    producerProps.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, SimpleConfigurationReader.getValue(KAFKA_SECURITY_PROTOCOL, KAFKA_SECURITY_PROTOCOL_DEFAULT));
-    producerProps.put(SslConfigs.SSL_PROTOCOL_CONFIG, SimpleConfigurationReader.getValue(KAFKA_SSL_PROTOCOL, KAFKA_SSL_PROTOCOL_DEFAULT));
-    producerProps.put(SslConfigs.SSL_KEY_PASSWORD_CONFIG, SimpleConfigurationReader.getValue(KAFKA_SSL_KEY_PASSWORD, null));
-    producerProps.put(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG, SimpleConfigurationReader.getValue(KAFKA_SSL_TRUSTSTORE_LOCATION, null));
-    producerProps.put(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG, SimpleConfigurationReader.getValue(KAFKA_SSL_TRUSTSTORE_PASSWORD, null));
-    producerProps.put(SslConfigs.SSL_TRUSTSTORE_TYPE_CONFIG, SimpleConfigurationReader.getValue(KAFKA_SSL_TRUSTSTORE_TYPE, KAFKA_SSL_TRUSTSTORE_TYPE_DEFAULT));
-    producerProps.put(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG, SimpleConfigurationReader.getValue(KAFKA_SSL_KEYSTORE_LOCATION, null));
-    producerProps.put(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG, SimpleConfigurationReader.getValue(KAFKA_SSL_KEYSTORE_PASSWORD, null));
-    producerProps.put(SslConfigs.SSL_KEYSTORE_TYPE_CONFIG, SimpleConfigurationReader.getValue(KAFKA_SSL_KEYSTORE_TYPE, KAFKA_SSL_KEYSTORE_TYPE_DEFAULT));
+    producerProps.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, SimpleConfigurationReader.getValue(
+      List.of(KAFKA_SECURITY_PROTOCOL_CONFIG, SpringKafkaProperties.KAFKA_SECURITY_PROTOCOL), KAFKA_SECURITY_PROTOCOL_DEFAULT));
+    producerProps.put(SslConfigs.SSL_PROTOCOL_CONFIG, SimpleConfigurationReader.getValue(
+      List.of(KAFKA_SSL_PROTOCOL_CONFIG, SpringKafkaProperties.KAFKA_SSL_PROTOCOL), KAFKA_SSL_PROTOCOL_DEFAULT));
+    producerProps.put(SslConfigs.SSL_KEY_PASSWORD_CONFIG, SimpleConfigurationReader.getValue(
+      List.of(KAFKA_SSL_KEY_PASSWORD_CONFIG, SpringKafkaProperties.KAFKA_SSL_KEY_PASSWORD), null));
+    producerProps.put(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG, SimpleConfigurationReader.getValue(
+      List.of(KAFKA_SSL_TRUSTSTORE_LOCATION_CONFIG, SpringKafkaProperties.KAFKA_SSL_TRUSTSTORE_LOCATION), null));
+    producerProps.put(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG, SimpleConfigurationReader.getValue(
+      List.of(KAFKA_SSL_TRUSTSTORE_PASSWORD_CONFIG, SpringKafkaProperties.KAFKA_SSL_TRUSTSTORE_PASSWORD), null));
+    producerProps.put(SslConfigs.SSL_TRUSTSTORE_TYPE_CONFIG, SimpleConfigurationReader.getValue(
+      List.of(KAFKA_SSL_TRUSTSTORE_TYPE_CONFIG, SpringKafkaProperties.KAFKA_SSL_TRUSTSTORE_TYPE), KAFKA_SSL_TRUSTSTORE_TYPE_DEFAULT));
+    producerProps.put(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG, SimpleConfigurationReader.getValue(
+      List.of(KAFKA_SSL_KEYSTORE_LOCATION_CONFIG, SpringKafkaProperties.KAFKA_SSL_KEYSTORE_LOCATION), null));
+    producerProps.put(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG, SimpleConfigurationReader.getValue(
+      List.of(KAFKA_SSL_KEYSTORE_PASSWORD_CONFIG, SpringKafkaProperties.KAFKA_SSL_KEYSTORE_PASSWORD), null));
+    producerProps.put(SslConfigs.SSL_KEYSTORE_TYPE_CONFIG, SimpleConfigurationReader.getValue(
+      List.of(KAFKA_SSL_KEYSTORE_TYPE_CONFIG, SpringKafkaProperties.KAFKA_SSL_KEYSTORE_TYPE), KAFKA_SSL_KEYSTORE_TYPE_DEFAULT));
     return producerProps;
   }
 
@@ -88,22 +98,35 @@ public class KafkaConfig {
     Map<String, String> consumerProps = new HashMap<>();
     consumerProps.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, getKafkaUrl());
     consumerProps.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false");
-    consumerProps.put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, SimpleConfigurationReader.getValue(KAFKA_CONSUMER_MAX_POLL_RECORDS_CONFIG, KAFKA_CONSUMER_MAX_POLL_RECORDS_CONFIG_DEFAULT));
-    consumerProps.put(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG, SimpleConfigurationReader.getValue(KAFKA_CONSUMER_MAX_POLL_INTERVAL_MS_CONFIG, KAFKA_CONSUMER_MAX_POLL_INTERVAL_MS_CONFIG_DEFAULT));
-    consumerProps.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, SimpleConfigurationReader.getValue(KAFKA_CONSUMER_AUTO_OFFSET_RESET_CONFIG, KAFKA_CONSUMER_AUTO_OFFSET_RESET_CONFIG_DEFAULT));
-    consumerProps.put(ConsumerConfig.METADATA_MAX_AGE_CONFIG, SimpleConfigurationReader.getValue(KAFKA_CONSUMER_METADATA_MAX_AGE_CONFIG, KAFKA_CONSUMER_METADATA_MAX_AGE_CONFIG_DEFAULT));
     consumerProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.StringDeserializer");
     consumerProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.StringDeserializer");
+    consumerProps.put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, SimpleConfigurationReader.getValue(
+      List.of(KAFKA_CONSUMER_MAX_POLL_RECORDS_CONFIG, SpringKafkaProperties.KAFKA_CONSUMER_MAX_POLL_RECORDS), KAFKA_CONSUMER_MAX_POLL_RECORDS_CONFIG_DEFAULT));
+    consumerProps.put(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG, SimpleConfigurationReader.getValue(
+      List.of(KAFKA_CONSUMER_MAX_POLL_INTERVAL_MS_CONFIG, SpringKafkaProperties.KAFKA_CONSUMER_MAX_POLL_INTERVAL_MS), KAFKA_CONSUMER_MAX_POLL_INTERVAL_MS_CONFIG_DEFAULT));
+    consumerProps.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, SimpleConfigurationReader.getValue(
+      List.of(KAFKA_CONSUMER_AUTO_OFFSET_RESET_CONFIG, SpringKafkaProperties.KAFKA_CONSUMER_AUTO_OFFSET_RESET), KAFKA_CONSUMER_AUTO_OFFSET_RESET_CONFIG_DEFAULT));
+    consumerProps.put(ConsumerConfig.METADATA_MAX_AGE_CONFIG, SimpleConfigurationReader.getValue(
+      List.of(KAFKA_CONSUMER_METADATA_MAX_AGE_CONFIG, SpringKafkaProperties.KAFKA_CONSUMER_METADATA_MAX_AGE), KAFKA_CONSUMER_METADATA_MAX_AGE_CONFIG_DEFAULT));
 
-    consumerProps.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, SimpleConfigurationReader.getValue(KAFKA_SECURITY_PROTOCOL, KAFKA_SECURITY_PROTOCOL_DEFAULT));
-    consumerProps.put(SslConfigs.SSL_PROTOCOL_CONFIG, SimpleConfigurationReader.getValue(KAFKA_SSL_PROTOCOL, KAFKA_SSL_PROTOCOL_DEFAULT));
-    consumerProps.put(SslConfigs.SSL_KEY_PASSWORD_CONFIG, SimpleConfigurationReader.getValue(KAFKA_SSL_KEY_PASSWORD, null));
-    consumerProps.put(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG, SimpleConfigurationReader.getValue(KAFKA_SSL_TRUSTSTORE_LOCATION, null));
-    consumerProps.put(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG, SimpleConfigurationReader.getValue(KAFKA_SSL_TRUSTSTORE_PASSWORD, null));
-    consumerProps.put(SslConfigs.SSL_TRUSTSTORE_TYPE_CONFIG, SimpleConfigurationReader.getValue(KAFKA_SSL_TRUSTSTORE_TYPE, KAFKA_SSL_TRUSTSTORE_TYPE_DEFAULT));
-    consumerProps.put(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG, SimpleConfigurationReader.getValue(KAFKA_SSL_KEYSTORE_LOCATION, null));
-    consumerProps.put(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG, SimpleConfigurationReader.getValue(KAFKA_SSL_KEYSTORE_PASSWORD, null));
-    consumerProps.put(SslConfigs.SSL_KEYSTORE_TYPE_CONFIG, SimpleConfigurationReader.getValue(KAFKA_SSL_KEYSTORE_TYPE, KAFKA_SSL_KEYSTORE_TYPE_DEFAULT));
+    consumerProps.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, SimpleConfigurationReader.getValue(
+      List.of(KAFKA_SECURITY_PROTOCOL_CONFIG, SpringKafkaProperties.KAFKA_SECURITY_PROTOCOL), KAFKA_SECURITY_PROTOCOL_DEFAULT));
+    consumerProps.put(SslConfigs.SSL_PROTOCOL_CONFIG, SimpleConfigurationReader.getValue(
+      List.of(KAFKA_SSL_PROTOCOL_CONFIG, SpringKafkaProperties.KAFKA_SSL_PROTOCOL), KAFKA_SSL_PROTOCOL_DEFAULT));
+    consumerProps.put(SslConfigs.SSL_KEY_PASSWORD_CONFIG, SimpleConfigurationReader.getValue(
+      List.of(KAFKA_SSL_KEY_PASSWORD_CONFIG, SpringKafkaProperties.KAFKA_SSL_KEY_PASSWORD), null));
+    consumerProps.put(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG, SimpleConfigurationReader.getValue(
+      List.of(KAFKA_SSL_TRUSTSTORE_LOCATION_CONFIG, SpringKafkaProperties.KAFKA_SSL_TRUSTSTORE_LOCATION), null));
+    consumerProps.put(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG, SimpleConfigurationReader.getValue(
+      List.of(KAFKA_SSL_TRUSTSTORE_PASSWORD_CONFIG, SpringKafkaProperties.KAFKA_SSL_TRUSTSTORE_PASSWORD), null));
+    consumerProps.put(SslConfigs.SSL_TRUSTSTORE_TYPE_CONFIG, SimpleConfigurationReader.getValue(
+      List.of(KAFKA_SSL_TRUSTSTORE_TYPE_CONFIG, SpringKafkaProperties.KAFKA_SSL_TRUSTSTORE_TYPE), KAFKA_SSL_TRUSTSTORE_TYPE_DEFAULT));
+    consumerProps.put(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG, SimpleConfigurationReader.getValue(
+      List.of(KAFKA_SSL_KEYSTORE_LOCATION_CONFIG, SpringKafkaProperties.KAFKA_SSL_KEYSTORE_LOCATION), null));
+    consumerProps.put(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG, SimpleConfigurationReader.getValue(
+      List.of(KAFKA_SSL_KEYSTORE_PASSWORD_CONFIG, SpringKafkaProperties.KAFKA_SSL_KEYSTORE_PASSWORD), null));
+    consumerProps.put(SslConfigs.SSL_KEYSTORE_TYPE_CONFIG, SimpleConfigurationReader.getValue(
+      List.of(KAFKA_SSL_KEYSTORE_TYPE_CONFIG, SpringKafkaProperties.KAFKA_SSL_KEYSTORE_TYPE), KAFKA_SSL_KEYSTORE_TYPE_DEFAULT));
     return consumerProps;
   }
 

--- a/folio-kafka-wrapper/src/main/java/org/folio/kafka/KafkaConfig.java
+++ b/folio-kafka-wrapper/src/main/java/org/folio/kafka/KafkaConfig.java
@@ -72,25 +72,7 @@ public class KafkaConfig {
     producerProps.put(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, "true");
     producerProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.StringSerializer");
     producerProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.StringSerializer");
-
-    producerProps.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, SimpleConfigurationReader.getValue(
-      List.of(KAFKA_SECURITY_PROTOCOL_CONFIG, SpringKafkaProperties.KAFKA_SECURITY_PROTOCOL), KAFKA_SECURITY_PROTOCOL_DEFAULT));
-    producerProps.put(SslConfigs.SSL_PROTOCOL_CONFIG, SimpleConfigurationReader.getValue(
-      List.of(KAFKA_SSL_PROTOCOL_CONFIG, SpringKafkaProperties.KAFKA_SSL_PROTOCOL), KAFKA_SSL_PROTOCOL_DEFAULT));
-    producerProps.put(SslConfigs.SSL_KEY_PASSWORD_CONFIG, SimpleConfigurationReader.getValue(
-      List.of(KAFKA_SSL_KEY_PASSWORD_CONFIG, SpringKafkaProperties.KAFKA_SSL_KEY_PASSWORD), null));
-    producerProps.put(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG, SimpleConfigurationReader.getValue(
-      List.of(KAFKA_SSL_TRUSTSTORE_LOCATION_CONFIG, SpringKafkaProperties.KAFKA_SSL_TRUSTSTORE_LOCATION), null));
-    producerProps.put(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG, SimpleConfigurationReader.getValue(
-      List.of(KAFKA_SSL_TRUSTSTORE_PASSWORD_CONFIG, SpringKafkaProperties.KAFKA_SSL_TRUSTSTORE_PASSWORD), null));
-    producerProps.put(SslConfigs.SSL_TRUSTSTORE_TYPE_CONFIG, SimpleConfigurationReader.getValue(
-      List.of(KAFKA_SSL_TRUSTSTORE_TYPE_CONFIG, SpringKafkaProperties.KAFKA_SSL_TRUSTSTORE_TYPE), KAFKA_SSL_TRUSTSTORE_TYPE_DEFAULT));
-    producerProps.put(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG, SimpleConfigurationReader.getValue(
-      List.of(KAFKA_SSL_KEYSTORE_LOCATION_CONFIG, SpringKafkaProperties.KAFKA_SSL_KEYSTORE_LOCATION), null));
-    producerProps.put(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG, SimpleConfigurationReader.getValue(
-      List.of(KAFKA_SSL_KEYSTORE_PASSWORD_CONFIG, SpringKafkaProperties.KAFKA_SSL_KEYSTORE_PASSWORD), null));
-    producerProps.put(SslConfigs.SSL_KEYSTORE_TYPE_CONFIG, SimpleConfigurationReader.getValue(
-      List.of(KAFKA_SSL_KEYSTORE_TYPE_CONFIG, SpringKafkaProperties.KAFKA_SSL_KEYSTORE_TYPE), KAFKA_SSL_KEYSTORE_TYPE_DEFAULT));
+    ensureSecurityProps(producerProps);
     return producerProps;
   }
 
@@ -100,6 +82,7 @@ public class KafkaConfig {
     consumerProps.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false");
     consumerProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.StringDeserializer");
     consumerProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.StringDeserializer");
+
     consumerProps.put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, SimpleConfigurationReader.getValue(
       List.of(KAFKA_CONSUMER_MAX_POLL_RECORDS_CONFIG, SpringKafkaProperties.KAFKA_CONSUMER_MAX_POLL_RECORDS), KAFKA_CONSUMER_MAX_POLL_RECORDS_CONFIG_DEFAULT));
     consumerProps.put(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG, SimpleConfigurationReader.getValue(
@@ -108,25 +91,7 @@ public class KafkaConfig {
       List.of(KAFKA_CONSUMER_AUTO_OFFSET_RESET_CONFIG, SpringKafkaProperties.KAFKA_CONSUMER_AUTO_OFFSET_RESET), KAFKA_CONSUMER_AUTO_OFFSET_RESET_CONFIG_DEFAULT));
     consumerProps.put(ConsumerConfig.METADATA_MAX_AGE_CONFIG, SimpleConfigurationReader.getValue(
       List.of(KAFKA_CONSUMER_METADATA_MAX_AGE_CONFIG, SpringKafkaProperties.KAFKA_CONSUMER_METADATA_MAX_AGE), KAFKA_CONSUMER_METADATA_MAX_AGE_CONFIG_DEFAULT));
-
-    consumerProps.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, SimpleConfigurationReader.getValue(
-      List.of(KAFKA_SECURITY_PROTOCOL_CONFIG, SpringKafkaProperties.KAFKA_SECURITY_PROTOCOL), KAFKA_SECURITY_PROTOCOL_DEFAULT));
-    consumerProps.put(SslConfigs.SSL_PROTOCOL_CONFIG, SimpleConfigurationReader.getValue(
-      List.of(KAFKA_SSL_PROTOCOL_CONFIG, SpringKafkaProperties.KAFKA_SSL_PROTOCOL), KAFKA_SSL_PROTOCOL_DEFAULT));
-    consumerProps.put(SslConfigs.SSL_KEY_PASSWORD_CONFIG, SimpleConfigurationReader.getValue(
-      List.of(KAFKA_SSL_KEY_PASSWORD_CONFIG, SpringKafkaProperties.KAFKA_SSL_KEY_PASSWORD), null));
-    consumerProps.put(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG, SimpleConfigurationReader.getValue(
-      List.of(KAFKA_SSL_TRUSTSTORE_LOCATION_CONFIG, SpringKafkaProperties.KAFKA_SSL_TRUSTSTORE_LOCATION), null));
-    consumerProps.put(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG, SimpleConfigurationReader.getValue(
-      List.of(KAFKA_SSL_TRUSTSTORE_PASSWORD_CONFIG, SpringKafkaProperties.KAFKA_SSL_TRUSTSTORE_PASSWORD), null));
-    consumerProps.put(SslConfigs.SSL_TRUSTSTORE_TYPE_CONFIG, SimpleConfigurationReader.getValue(
-      List.of(KAFKA_SSL_TRUSTSTORE_TYPE_CONFIG, SpringKafkaProperties.KAFKA_SSL_TRUSTSTORE_TYPE), KAFKA_SSL_TRUSTSTORE_TYPE_DEFAULT));
-    consumerProps.put(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG, SimpleConfigurationReader.getValue(
-      List.of(KAFKA_SSL_KEYSTORE_LOCATION_CONFIG, SpringKafkaProperties.KAFKA_SSL_KEYSTORE_LOCATION), null));
-    consumerProps.put(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG, SimpleConfigurationReader.getValue(
-      List.of(KAFKA_SSL_KEYSTORE_PASSWORD_CONFIG, SpringKafkaProperties.KAFKA_SSL_KEYSTORE_PASSWORD), null));
-    consumerProps.put(SslConfigs.SSL_KEYSTORE_TYPE_CONFIG, SimpleConfigurationReader.getValue(
-      List.of(KAFKA_SSL_KEYSTORE_TYPE_CONFIG, SpringKafkaProperties.KAFKA_SSL_KEYSTORE_TYPE), KAFKA_SSL_KEYSTORE_TYPE_DEFAULT));
+    ensureSecurityProps(consumerProps);
     return consumerProps;
   }
 
@@ -144,6 +109,27 @@ public class KafkaConfig {
 
   public int getNumberOfPartitions() {
     return Integer.parseInt(SimpleConfigurationReader.getValue(KAFKA_NUMBER_OF_PARTITIONS, KAFKA_NUMBER_OF_PARTITIONS_DEFAULT));
+  }
+
+  private void ensureSecurityProps(Map<String, String> clientProps) {
+    clientProps.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, SimpleConfigurationReader.getValue(
+      List.of(KAFKA_SECURITY_PROTOCOL_CONFIG, SpringKafkaProperties.KAFKA_SECURITY_PROTOCOL), KAFKA_SECURITY_PROTOCOL_DEFAULT));
+    clientProps.put(SslConfigs.SSL_PROTOCOL_CONFIG, SimpleConfigurationReader.getValue(
+      List.of(KAFKA_SSL_PROTOCOL_CONFIG, SpringKafkaProperties.KAFKA_SSL_PROTOCOL), KAFKA_SSL_PROTOCOL_DEFAULT));
+    clientProps.put(SslConfigs.SSL_KEY_PASSWORD_CONFIG, SimpleConfigurationReader.getValue(
+      List.of(KAFKA_SSL_KEY_PASSWORD_CONFIG, SpringKafkaProperties.KAFKA_SSL_KEY_PASSWORD), null));
+    clientProps.put(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG, SimpleConfigurationReader.getValue(
+      List.of(KAFKA_SSL_TRUSTSTORE_LOCATION_CONFIG, SpringKafkaProperties.KAFKA_SSL_TRUSTSTORE_LOCATION), null));
+    clientProps.put(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG, SimpleConfigurationReader.getValue(
+      List.of(KAFKA_SSL_TRUSTSTORE_PASSWORD_CONFIG, SpringKafkaProperties.KAFKA_SSL_TRUSTSTORE_PASSWORD), null));
+    clientProps.put(SslConfigs.SSL_TRUSTSTORE_TYPE_CONFIG, SimpleConfigurationReader.getValue(
+      List.of(KAFKA_SSL_TRUSTSTORE_TYPE_CONFIG, SpringKafkaProperties.KAFKA_SSL_TRUSTSTORE_TYPE), KAFKA_SSL_TRUSTSTORE_TYPE_DEFAULT));
+    clientProps.put(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG, SimpleConfigurationReader.getValue(
+      List.of(KAFKA_SSL_KEYSTORE_LOCATION_CONFIG, SpringKafkaProperties.KAFKA_SSL_KEYSTORE_LOCATION), null));
+    clientProps.put(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG, SimpleConfigurationReader.getValue(
+      List.of(KAFKA_SSL_KEYSTORE_PASSWORD_CONFIG, SpringKafkaProperties.KAFKA_SSL_KEYSTORE_PASSWORD), null));
+    clientProps.put(SslConfigs.SSL_KEYSTORE_TYPE_CONFIG, SimpleConfigurationReader.getValue(
+      List.of(KAFKA_SSL_KEYSTORE_TYPE_CONFIG, SpringKafkaProperties.KAFKA_SSL_KEYSTORE_TYPE), KAFKA_SSL_KEYSTORE_TYPE_DEFAULT));
   }
 
 }

--- a/folio-kafka-wrapper/src/main/java/org/folio/kafka/KafkaConfig.java
+++ b/folio-kafka-wrapper/src/main/java/org/folio/kafka/KafkaConfig.java
@@ -4,8 +4,10 @@ import io.kcache.KafkaCacheConfig;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.ToString;
+import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.config.SslConfigs;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -32,6 +34,28 @@ public class KafkaConfig {
   public static final String KAFKA_CONSUMER_MAX_POLL_INTERVAL_MS_CONFIG = "kafka.consumer.max.poll.interval.ms";
   public static final String KAFKA_CONSUMER_MAX_POLL_INTERVAL_MS_CONFIG_DEFAULT = "300000";
 
+  public static final String KAFKA_SECURITY_PROTOCOL = "security.protocol";
+  public static final String KAFKA_SECURITY_PROTOCOL_DEFAULT = "PLAINTEXT";
+
+  public static final String KAFKA_SSL_PROTOCOL = "ssl.protocol";
+  public static final String KAFKA_SSL_PROTOCOL_DEFAULT = "TLSv1.2";
+
+  public static final String KAFKA_SSL_KEY_PASSWORD = "ssl.key.password";
+
+  public static final String KAFKA_SSL_TRUSTSTORE_LOCATION = "ssl.truststore.location";
+
+  public static final String KAFKA_SSL_TRUSTSTORE_PASSWORD = "ssl.truststore.password";
+
+  public static final String KAFKA_SSL_TRUSTSTORE_TYPE = "ssl.truststore.type";
+  public static final String KAFKA_SSL_TRUSTSTORE_TYPE_DEFAULT = "JKS";
+
+  public static final String KAFKA_SSL_KEYSTORE_LOCATION = "ssl.keystore.location";
+
+  public static final String KAFKA_SSL_KEYSTORE_PASSWORD = "ssl.keystore.password";
+
+  public static final String KAFKA_SSL_KEYSTORE_TYPE = "ssl.keystore.type";
+  public static final String KAFKA_SSL_KEYSTORE_TYPE_DEFAULT = "JKS";
+
   private static final String KAFKA_CACHE_TOPIC_PROPERTY = "kafkacache.topic";
   private static final String KAFKA_CACHE_TOPIC_PROPERTY_DEFAULT = "events_cache";
 
@@ -47,6 +71,16 @@ public class KafkaConfig {
     producerProps.put(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, "true");
     producerProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.StringSerializer");
     producerProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.StringSerializer");
+
+    producerProps.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, SimpleConfigurationReader.getValue(KAFKA_SECURITY_PROTOCOL, KAFKA_SECURITY_PROTOCOL_DEFAULT));
+    producerProps.put(SslConfigs.SSL_PROTOCOL_CONFIG, SimpleConfigurationReader.getValue(KAFKA_SSL_PROTOCOL, KAFKA_SSL_PROTOCOL_DEFAULT));
+    producerProps.put(SslConfigs.SSL_KEY_PASSWORD_CONFIG, SimpleConfigurationReader.getValue(KAFKA_SSL_KEY_PASSWORD, null));
+    producerProps.put(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG, SimpleConfigurationReader.getValue(KAFKA_SSL_TRUSTSTORE_LOCATION, null));
+    producerProps.put(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG, SimpleConfigurationReader.getValue(KAFKA_SSL_TRUSTSTORE_PASSWORD, null));
+    producerProps.put(SslConfigs.SSL_TRUSTSTORE_TYPE_CONFIG, SimpleConfigurationReader.getValue(KAFKA_SSL_TRUSTSTORE_TYPE, KAFKA_SSL_TRUSTSTORE_TYPE_DEFAULT));
+    producerProps.put(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG, SimpleConfigurationReader.getValue(KAFKA_SSL_KEYSTORE_LOCATION, null));
+    producerProps.put(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG, SimpleConfigurationReader.getValue(KAFKA_SSL_KEYSTORE_PASSWORD, null));
+    producerProps.put(SslConfigs.SSL_KEYSTORE_TYPE_CONFIG, SimpleConfigurationReader.getValue(KAFKA_SSL_KEYSTORE_TYPE, KAFKA_SSL_KEYSTORE_TYPE_DEFAULT));
     return producerProps;
   }
 
@@ -60,6 +94,16 @@ public class KafkaConfig {
     consumerProps.put(ConsumerConfig.METADATA_MAX_AGE_CONFIG, SimpleConfigurationReader.getValue(KAFKA_CONSUMER_METADATA_MAX_AGE_CONFIG, KAFKA_CONSUMER_METADATA_MAX_AGE_CONFIG_DEFAULT));
     consumerProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.StringDeserializer");
     consumerProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.StringDeserializer");
+
+    consumerProps.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, SimpleConfigurationReader.getValue(KAFKA_SECURITY_PROTOCOL, KAFKA_SECURITY_PROTOCOL_DEFAULT));
+    consumerProps.put(SslConfigs.SSL_PROTOCOL_CONFIG, SimpleConfigurationReader.getValue(KAFKA_SSL_PROTOCOL, KAFKA_SSL_PROTOCOL_DEFAULT));
+    consumerProps.put(SslConfigs.SSL_KEY_PASSWORD_CONFIG, SimpleConfigurationReader.getValue(KAFKA_SSL_KEY_PASSWORD, null));
+    consumerProps.put(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG, SimpleConfigurationReader.getValue(KAFKA_SSL_TRUSTSTORE_LOCATION, null));
+    consumerProps.put(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG, SimpleConfigurationReader.getValue(KAFKA_SSL_TRUSTSTORE_PASSWORD, null));
+    consumerProps.put(SslConfigs.SSL_TRUSTSTORE_TYPE_CONFIG, SimpleConfigurationReader.getValue(KAFKA_SSL_TRUSTSTORE_TYPE, KAFKA_SSL_TRUSTSTORE_TYPE_DEFAULT));
+    consumerProps.put(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG, SimpleConfigurationReader.getValue(KAFKA_SSL_KEYSTORE_LOCATION, null));
+    consumerProps.put(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG, SimpleConfigurationReader.getValue(KAFKA_SSL_KEYSTORE_PASSWORD, null));
+    consumerProps.put(SslConfigs.SSL_KEYSTORE_TYPE_CONFIG, SimpleConfigurationReader.getValue(KAFKA_SSL_KEYSTORE_TYPE, KAFKA_SSL_KEYSTORE_TYPE_DEFAULT));
     return consumerProps;
   }
 

--- a/folio-kafka-wrapper/src/main/java/org/folio/kafka/SimpleConfigurationReader.java
+++ b/folio-kafka-wrapper/src/main/java/org/folio/kafka/SimpleConfigurationReader.java
@@ -9,7 +9,7 @@ public class SimpleConfigurationReader {
   }
 
   public static String getValue(String key, String defValue) {
-    String value = System.getenv(key);
+    String value = System.getProperty(key, System.getenv(key));
     return value != null ? value : defValue;
   }
 

--- a/folio-kafka-wrapper/src/main/java/org/folio/kafka/SimpleConfigurationReader.java
+++ b/folio-kafka-wrapper/src/main/java/org/folio/kafka/SimpleConfigurationReader.java
@@ -1,6 +1,8 @@
 package org.folio.kafka;
 
 
+import java.util.List;
+
 public class SimpleConfigurationReader {
   private SimpleConfigurationReader() {
     super();
@@ -9,5 +11,15 @@ public class SimpleConfigurationReader {
   public static String getValue(String key, String defValue) {
     String value = System.getenv(key);
     return value != null ? value : defValue;
+  }
+
+  public static String getValue(List<String> keys, String defValue) {
+    for (String key : keys) {
+      String value = System.getProperty(key, System.getenv(key));
+      if (value != null) {
+        return value;
+      }
+    }
+    return defValue;
   }
 }

--- a/folio-kafka-wrapper/src/main/java/org/folio/kafka/SpringKafkaProperties.java
+++ b/folio-kafka-wrapper/src/main/java/org/folio/kafka/SpringKafkaProperties.java
@@ -1,0 +1,34 @@
+package org.folio.kafka;
+
+public final class SpringKafkaProperties {
+
+  public static final String KAFKA_CONSUMER_AUTO_OFFSET_RESET = "spring.kafka.consumer.auto-offset-reset";
+
+  public static final String KAFKA_CONSUMER_METADATA_MAX_AGE = "spring.kafka.consumer.properties.metadata.max.age.ms";
+
+  public static final String KAFKA_CONSUMER_MAX_POLL_RECORDS = "spring.kafka.consumer.max-poll-records";
+
+  public static final String KAFKA_CONSUMER_MAX_POLL_INTERVAL_MS = "spring.kafka.consumer.properties.max.poll.interval.ms";
+
+  public static final String KAFKA_SECURITY_PROTOCOL = "spring.kafka.security.protocol";
+
+  public static final String KAFKA_SSL_PROTOCOL = "spring.kafka.ssl.protocol";
+
+  public static final String KAFKA_SSL_KEY_PASSWORD = "spring.kafka.ssl.key-password";
+
+  public static final String KAFKA_SSL_TRUSTSTORE_LOCATION = "spring.kafka.ssl.trust-store-location";
+
+  public static final String KAFKA_SSL_TRUSTSTORE_PASSWORD = "spring.kafka.ssl.trust-store-password";
+
+  public static final String KAFKA_SSL_TRUSTSTORE_TYPE = "spring.kafka.ssl.trust-store-type";
+
+  public static final String KAFKA_SSL_KEYSTORE_LOCATION = "spring.kafka.ssl.key-store-location";
+
+  public static final String KAFKA_SSL_KEYSTORE_PASSWORD = "spring.kafka.ssl.key-store-password";
+
+  public static final String KAFKA_SSL_KEYSTORE_TYPE = "spring.kafka.ssl.key-store-type";
+
+  private SpringKafkaProperties() {
+    throw new UnsupportedOperationException();
+  }
+}

--- a/folio-kafka-wrapper/src/test/java/org/folio/kafka/KafkaConfigTest.java
+++ b/folio-kafka-wrapper/src/test/java/org/folio/kafka/KafkaConfigTest.java
@@ -1,0 +1,45 @@
+package org.folio.kafka;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Map;
+
+import static org.junit.Assert.*;
+
+public class KafkaConfigTest {
+
+    @Test
+    public void shouldReturnProducerProperties() {
+      Map<String, String> producerProps = KafkaConfig.builder()
+        .kafkaHost("127.0.0.1")
+        .kafkaPort("9092")
+        .build()
+        .getProducerProps();
+
+      Assert.assertEquals("127.0.0.1:9092", producerProps.get(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG));
+      Assert.assertEquals("true", producerProps.get(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG));
+      Assert.assertEquals("org.apache.kafka.common.serialization.StringSerializer", producerProps.get(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG));
+      Assert.assertEquals("org.apache.kafka.common.serialization.StringSerializer", producerProps.get(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG));
+    }
+
+    @Test
+    public void shouldReturnConsumerProperties() {
+      String maxPullRecordsValue = "500";
+      System.setProperty(KafkaConfig.KAFKA_CONSUMER_MAX_POLL_RECORDS_CONFIG, maxPullRecordsValue);
+
+      Map<String, String> consumerProps = KafkaConfig.builder()
+        .kafkaHost("127.0.0.1")
+        .kafkaPort("9092")
+        .build()
+        .getConsumerProps();
+
+      Assert.assertEquals("127.0.0.1:9092", consumerProps.get(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG));
+      Assert.assertEquals(KafkaConfig.KAFKA_CONSUMER_METADATA_MAX_AGE_CONFIG_DEFAULT, consumerProps.get(ConsumerConfig.METADATA_MAX_AGE_CONFIG));
+      Assert.assertEquals(KafkaConfig.KAFKA_CONSUMER_MAX_POLL_INTERVAL_MS_CONFIG_DEFAULT, consumerProps.get(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG));
+      Assert.assertEquals(maxPullRecordsValue, consumerProps.get(ConsumerConfig.MAX_POLL_RECORDS_CONFIG));
+    }
+
+}

--- a/folio-kafka-wrapper/src/test/java/org/folio/kafka/SimpleConfigurationReaderTest.java
+++ b/folio-kafka-wrapper/src/test/java/org/folio/kafka/SimpleConfigurationReaderTest.java
@@ -1,0 +1,41 @@
+package org.folio.kafka;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+public class SimpleConfigurationReaderTest {
+
+  @Test
+  public void shouldReadValueFromSystemProperty() {
+    String expectedValue = "testValue";
+    System.setProperty("test.props", expectedValue);
+    String actualValue = SimpleConfigurationReader.getValue("test.props", null);
+    Assert.assertEquals(expectedValue, actualValue);
+  }
+
+  @Test
+  public void shouldReturnDefaultValueIfNoSysPropertyOrEnvVariable() {
+    String defaultValue = "testValue";
+    String actualValue = SimpleConfigurationReader.getValue("test.props", defaultValue);
+    Assert.assertEquals(defaultValue, actualValue);
+  }
+
+  @Test
+  public void shouldReadValueFromSystemPropertyBySecondKey() {
+    String expectedValue = "testValue";
+    System.setProperty("test.props2", expectedValue);
+    String actualValue = SimpleConfigurationReader.getValue(List.of("test.props1", "test.props2"), null);
+    Assert.assertEquals(expectedValue, actualValue);
+  }
+
+  @Test
+  public void shouldReturnDefaultValueIfNoValueForSpecifiedKeys() {
+    String defaultValue = "testValue";
+    String actualValue = SimpleConfigurationReader.getValue(List.of("test.props1", "test.props2"), defaultValue);
+    Assert.assertEquals(defaultValue, actualValue);
+  }
+}


### PR DESCRIPTION
## Purpose
to ensure producer/consumer configuration necessary for kafka security needs

## Approach
* provide necessary properties for kafka security
* ensure properties lookup order: 1)in sys properties, 2)in env variables
* add support for reading necessary spring boot kafka related properties (as an alternative source for properties values)


## Learning
[MODPUBSUB-171](https://issues.folio.org/browse/MODPUBSUB-171)
https://wiki.folio.org/pages/viewpage.action?spaceKey=~mage.air&title=Kafka+Security
https://wiki.folio.org/pages/viewpage.action?spaceKey=FOLIJET&title=Enabling+SSL+and+ACL+for+Kafka
https://kafka.apache.org/25/documentation.html#security.protocol
https://docs.spring.io/spring-boot/docs/current/reference/html/application-properties.html#application-properties.integration.spring.kafka.consumer.auto-offset-reset