### PR TITLE
MODPUBSUB-181: mod-source-record-manager unable to create Kafka topics if tenant ID doesn't match \w{4,}

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+## 2021-XX-XX v2.4.0-SNAPSHOT
+* [MODPUBSUB-181](https://issues.folio.org/browse/MODPUBSUB-181) mod-source-record-manager unable to create Kafka topics if tenant ID doesn't match \w{4,}
+
+
+
 ## 2021-06-10 v2.3.0
 * [MODPUBSUB-179](https://issues.folio.org/browse/MODPUBSUB-179) Use local PomReader to retrieve module name and version
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,6 @@
 ## 2021-XX-XX v2.4.0-SNAPSHOT
 * [MODPUBSUB-181](https://issues.folio.org/browse/MODPUBSUB-181) mod-source-record-manager unable to create Kafka topics if tenant ID doesn't match \w{4,}
 
-
-
 ## 2021-06-10 v2.3.0
 * [MODPUBSUB-179](https://issues.folio.org/browse/MODPUBSUB-179) Use local PomReader to retrieve module name and version
 

--- a/folio-kafka-wrapper/src/main/java/org/folio/kafka/KafkaTopicNameHelper.java
+++ b/folio-kafka-wrapper/src/main/java/org/folio/kafka/KafkaTopicNameHelper.java
@@ -11,12 +11,10 @@ public class KafkaTopicNameHelper {
     super();
   }
 
-  //TODO: add unit test
   public static String formatTopicName(String env, String nameSpace, String tenant, String eventType) {
     return join(".", env, nameSpace, tenant, eventType);
   }
 
-  //TODO: add unit test
   public static String getEventTypeFromTopicName(String topic) {
     int eventTypeIndex = StringUtils.isBlank(topic) ? -1 : topic.lastIndexOf('.') + 1;
     if (eventTypeIndex > 0) {
@@ -26,21 +24,18 @@ public class KafkaTopicNameHelper {
     }
   }
 
-  //TODO: add unit test
   public static String formatGroupName(String eventType, String moduleName) {
     return join(".", eventType, moduleName);
   }
 
-  //TODO: add unit test
   public static String formatSubscriptionPattern(String env, String nameSpace, String eventType) {
-    return join("\\.", env, nameSpace, "\\w{4,}", eventType);
+    return join("\\.", env, nameSpace, "\\w{1,}", eventType);
   }
 
   public static String getDefaultNameSpace() {
     return DEFAULT_NAMESPACE;
   }
 
-  //TODO: add unit test
   public static SubscriptionDefinition createSubscriptionDefinition(String env, String nameSpace, String eventType) {
     return SubscriptionDefinition.builder()
       .eventType(eventType)

--- a/folio-kafka-wrapper/src/test/java/org/folio/kafka/KafkaTopicNameHelperTest.java
+++ b/folio-kafka-wrapper/src/test/java/org/folio/kafka/KafkaTopicNameHelperTest.java
@@ -1,0 +1,62 @@
+package org.folio.kafka;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.regex.Pattern;
+
+import org.junit.Test;
+
+public class KafkaTopicNameHelperTest {
+
+  @Test
+  public void shouldFormatSubscriptionPatternForTenantAnySymbolWithAnyLength() {
+    String subscriptionPattern = KafkaTopicNameHelper.formatSubscriptionPattern("folio", "Default", "DI_COMPLETED");
+    Pattern pattern = Pattern.compile(subscriptionPattern);
+    assertNotNull(subscriptionPattern);
+    assertTrue(pattern.matcher("folio.Default.test.DI_COMPLETED").matches());
+    assertTrue(pattern.matcher("folio.Default.tes.DI_COMPLETED").matches());
+    assertTrue(pattern.matcher("folio.Default.te.DI_COMPLETED").matches());
+    assertTrue(pattern.matcher("folio.Default.t.DI_COMPLETED").matches());
+    assertTrue(pattern.matcher("folio.Default.t1.DI_COMPLETED").matches());
+    assertTrue(pattern.matcher("folio.Default.1.DI_COMPLETED").matches());
+    assertTrue(pattern.matcher("folio.Default.1.DI_COMPLETED").matches());
+  }
+
+  @Test
+  public void shouldBuildSubscriptionDefinition() {
+    SubscriptionDefinition subscriptionDefinition = KafkaTopicNameHelper.createSubscriptionDefinition("folio", "Default", "DI_COMPLETED");
+    assertNotNull(subscriptionDefinition);
+    assertNotNull(subscriptionDefinition.getEventType());
+    assertEquals(subscriptionDefinition.getEventType(), "DI_COMPLETED");
+    assertNotNull(subscriptionDefinition.getSubscriptionPattern());
+    assertEquals("folio\\.Default\\.\\w{1,}\\.DI_COMPLETED", subscriptionDefinition.getSubscriptionPattern());
+  }
+
+  @Test
+  public void shouldFormatGroupName() {
+    String subscriptionDefinition = KafkaTopicNameHelper.formatGroupName("DI_COMPLETED", "folio-kafka-wrapper");
+    assertNotNull(subscriptionDefinition);
+    assertEquals("DI_COMPLETED.folio-kafka-wrapper", subscriptionDefinition);
+  }
+
+  @Test
+  public void shouldGetEventTypeFromTopicName() {
+    String eventType = KafkaTopicNameHelper.getEventTypeFromTopicName("folio.Default.test.DI_COMPLETED");
+    assertNotNull(eventType);
+    assertEquals("DI_COMPLETED", eventType);
+  }
+
+  @Test(expected = RuntimeException.class)
+  public void shouldThrowRuntimeExceptionGetEventTypeFromTopicName() {
+    KafkaTopicNameHelper.getEventTypeFromTopicName("folio,Default;test#DI_COMPLETED");
+  }
+
+  @Test
+  public void shouldFormatTopicName() {
+    String topicName = KafkaTopicNameHelper.formatTopicName("folio", "Default", "test","DI_COMPLETED");
+    assertNotNull(topicName);
+    assertEquals("folio.Default.test.DI_COMPLETED", topicName);
+  }
+}

--- a/folio-kafka-wrapper/src/test/java/org/folio/kafka/KafkaTopicNameHelperTest.java
+++ b/folio-kafka-wrapper/src/test/java/org/folio/kafka/KafkaTopicNameHelperTest.java
@@ -29,7 +29,7 @@ public class KafkaTopicNameHelperTest {
     SubscriptionDefinition subscriptionDefinition = KafkaTopicNameHelper.createSubscriptionDefinition("folio", "Default", "DI_COMPLETED");
     assertNotNull(subscriptionDefinition);
     assertNotNull(subscriptionDefinition.getEventType());
-    assertEquals(subscriptionDefinition.getEventType(), "DI_COMPLETED");
+    assertEquals( "DI_COMPLETED", subscriptionDefinition.getEventType());
     assertNotNull(subscriptionDefinition.getSubscriptionPattern());
     assertEquals("folio\\.Default\\.\\w{1,}\\.DI_COMPLETED", subscriptionDefinition.getSubscriptionPattern());
   }


### PR DESCRIPTION
## Purpose
Enable kafka topic to create for tenant where there are less than 4 symbols.

## Approach
1. Change subscription definition pattern to accept from 1 symbol and more.
2. Tests added for KafkaTopicNameHelper.
3. NEWS updated.

## Learning
https://issues.folio.org/browse/MODPUBSUB-181