### PR TITLE
MODPUBSUB-182: Provide properties for Kafka security in mod-pubsub

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 ## 2021-XX-XX v2.4.0-SNAPSHOT
 * [MODPUBSUB-181](https://issues.folio.org/browse/MODPUBSUB-181) mod-source-record-manager unable to create Kafka topics if tenant ID doesn't match \w{4,}
+* [MODPUBSUB-182](https://issues.folio.org/browse/MODPUBSUB-182) Provide properties for Kafka security in mod-pubsub.
 
 ## 2021-06-10 v2.3.0
 * [MODPUBSUB-179](https://issues.folio.org/browse/MODPUBSUB-179) Use local PomReader to retrieve module name and version

--- a/mod-pubsub-server/pom.xml
+++ b/mod-pubsub-server/pom.xml
@@ -96,6 +96,7 @@
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-kafka-client</artifactId>
+      <version>${vertx.version}</version>
       <exclusions>
         <exclusion>
           <groupId>org.apache.kafka</groupId>

--- a/mod-pubsub-server/pom.xml
+++ b/mod-pubsub-server/pom.xml
@@ -96,7 +96,6 @@
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-kafka-client</artifactId>
-      <version>${vertx.version}</version>
       <exclusions>
         <exclusion>
           <groupId>org.apache.kafka</groupId>
@@ -107,7 +106,7 @@
     <dependency>
       <groupId>org.apache.kafka</groupId>
       <artifactId>kafka-clients</artifactId>
-      <version>2.5.0</version>
+      <version>2.6.0</version>
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>

--- a/mod-pubsub-server/pom.xml
+++ b/mod-pubsub-server/pom.xml
@@ -12,7 +12,6 @@
     <basedir>${project.parent.basedir}</basedir>
     <ramlfiles_path>${project.parent.basedir}/ramls</ramlfiles_path>
     <sonar.exclusions>**/OkapiConnectionParams.java</sonar.exclusions>
-    <sonar.exclusions>org.folio.kafka.SpringKafkaProperties</sonar.exclusions>
   </properties>
 
   <dependencies>

--- a/mod-pubsub-server/pom.xml
+++ b/mod-pubsub-server/pom.xml
@@ -12,6 +12,7 @@
     <basedir>${project.parent.basedir}</basedir>
     <ramlfiles_path>${project.parent.basedir}/ramls</ramlfiles_path>
     <sonar.exclusions>**/OkapiConnectionParams.java</sonar.exclusions>
+    <sonar.exclusions>org.folio.kafka.SpringKafkaProperties</sonar.exclusions>
   </properties>
 
   <dependencies>

--- a/mod-pubsub-server/pom.xml
+++ b/mod-pubsub-server/pom.xml
@@ -106,7 +106,7 @@
     <dependency>
       <groupId>org.apache.kafka</groupId>
       <artifactId>kafka-clients</artifactId>
-      <version>2.6.0</version>
+      <version>2.5.0</version>
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>

--- a/mod-pubsub-server/src/main/java/org/folio/kafka/KafkaConfig.java
+++ b/mod-pubsub-server/src/main/java/org/folio/kafka/KafkaConfig.java
@@ -1,7 +1,10 @@
 package org.folio.kafka;
 
+import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.config.SslConfigs;
+import org.folio.rest.util.SimpleConfigurationReader;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
@@ -23,6 +26,29 @@ public class KafkaConfig {
   private int numberOfPartitions;
   @Value("${ENV:folio}")
   private String envId;
+  @Value("${security.protocol}")
+  private String kafkaSecurityProtocolConfig;
+  @Value("${ssl.protocol}")
+  private String kafkaSslProtocolConfig;
+  @Value("${ssl.key.password}")
+  private String kafkaSslKeyPasswordConfig;
+  @Value("${ssl.truststore.location}")
+  private String kafkaSslTruststoreLocationConfig;
+  @Value("${ssl.truststore.password}")
+  private String kafkaSslTruststorePasswordConfig;
+  @Value("${ssl.truststore.type}")
+  private String kafkaSslTruststoreTypeConfig;
+  @Value("${ssl.keystore.location}")
+  private String kafkaSslKeystoreLocationConfig;
+  @Value("${ssl.keystore.password}")
+  private String kafkaSslKeystorePasswordConfig;
+  @Value("${ssl.keystore.type}")
+  private String kafkaSslKeystoreTypeConfig;
+
+  public static final String KAFKA_SECURITY_PROTOCOL_DEFAULT = "PLAINTEXT";
+  public static final String KAFKA_SSL_PROTOCOL_DEFAULT = "TLSv1.2";
+  public static final String KAFKA_SSL_TRUSTSTORE_TYPE_DEFAULT = "JKS";
+  public static final String KAFKA_SSL_KEYSTORE_TYPE_DEFAULT = "JKS";
 
   public String getKafkaHost() {
     return kafkaHost;
@@ -42,6 +68,7 @@ public class KafkaConfig {
     producerProps.put(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, "true");
     producerProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.StringSerializer");
     producerProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.StringSerializer");
+    ensureSecurityProps(producerProps);
     return producerProps;
   }
 
@@ -52,6 +79,7 @@ public class KafkaConfig {
     consumerProps.put(ConsumerConfig.AUTO_COMMIT_INTERVAL_MS_CONFIG, "1000");
     consumerProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.StringDeserializer");
     consumerProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.StringDeserializer");
+    ensureSecurityProps(consumerProps);
     return consumerProps;
   }
 
@@ -69,5 +97,26 @@ public class KafkaConfig {
 
   public String getEnvId() {
     return envId;
+  }
+
+  private void ensureSecurityProps(Map<String, String> clientProps) {
+    clientProps.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, SimpleConfigurationReader.getValue(
+      kafkaSecurityProtocolConfig, SpringKafkaProperties.KAFKA_SECURITY_PROTOCOL, KAFKA_SECURITY_PROTOCOL_DEFAULT));
+    clientProps.put(SslConfigs.SSL_PROTOCOL_CONFIG, SimpleConfigurationReader.getValue(
+      kafkaSslProtocolConfig, SpringKafkaProperties.KAFKA_SSL_PROTOCOL, KAFKA_SSL_PROTOCOL_DEFAULT));
+    clientProps.put(SslConfigs.SSL_KEY_PASSWORD_CONFIG, SimpleConfigurationReader.getValue(
+      kafkaSslKeyPasswordConfig, SpringKafkaProperties.KAFKA_SSL_KEY_PASSWORD, null));
+    clientProps.put(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG, SimpleConfigurationReader.getValue(
+      kafkaSslTruststoreLocationConfig, SpringKafkaProperties.KAFKA_SSL_TRUSTSTORE_LOCATION, null));
+    clientProps.put(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG, SimpleConfigurationReader.getValue(
+      kafkaSslTruststorePasswordConfig, SpringKafkaProperties.KAFKA_SSL_TRUSTSTORE_PASSWORD, null));
+    clientProps.put(SslConfigs.SSL_TRUSTSTORE_TYPE_CONFIG, SimpleConfigurationReader.getValue(
+      kafkaSslTruststoreTypeConfig, SpringKafkaProperties.KAFKA_SSL_TRUSTSTORE_TYPE, KAFKA_SSL_TRUSTSTORE_TYPE_DEFAULT));
+    clientProps.put(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG, SimpleConfigurationReader.getValue(
+      kafkaSslKeystoreLocationConfig, SpringKafkaProperties.KAFKA_SSL_KEYSTORE_LOCATION, null));
+    clientProps.put(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG, SimpleConfigurationReader.getValue(
+      kafkaSslKeystorePasswordConfig, SpringKafkaProperties.KAFKA_SSL_KEYSTORE_PASSWORD, null));
+    clientProps.put(SslConfigs.SSL_KEYSTORE_TYPE_CONFIG, SimpleConfigurationReader.getValue(
+      kafkaSslKeystoreTypeConfig, SpringKafkaProperties.KAFKA_SSL_KEYSTORE_TYPE, KAFKA_SSL_KEYSTORE_TYPE_DEFAULT));
   }
 }

--- a/mod-pubsub-server/src/main/java/org/folio/kafka/KafkaConfig.java
+++ b/mod-pubsub-server/src/main/java/org/folio/kafka/KafkaConfig.java
@@ -99,7 +99,7 @@ public class KafkaConfig {
     return envId;
   }
 
-  private void ensureSecurityProps(Map<String, String> clientProps) {
+  private void ensureSecurityProps(Map<String, String> clientProps) {//NOSONAR
     clientProps.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, SimpleConfigurationReader.getValue(
       kafkaSecurityProtocolConfig, SpringKafkaProperties.KAFKA_SECURITY_PROTOCOL, KAFKA_SECURITY_PROTOCOL_DEFAULT));
     clientProps.put(SslConfigs.SSL_PROTOCOL_CONFIG, SimpleConfigurationReader.getValue(

--- a/mod-pubsub-server/src/main/java/org/folio/kafka/KafkaConfig.java
+++ b/mod-pubsub-server/src/main/java/org/folio/kafka/KafkaConfig.java
@@ -99,7 +99,7 @@ public class KafkaConfig {
     return envId;
   }
 
-  private void ensureSecurityProps(Map<String, String> clientProps) {//NOSONAR
+  private void ensureSecurityProps(Map<String, String> clientProps) {  //NOSONAR
     clientProps.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, SimpleConfigurationReader.getValue(
       kafkaSecurityProtocolConfig, SpringKafkaProperties.KAFKA_SECURITY_PROTOCOL, KAFKA_SECURITY_PROTOCOL_DEFAULT));
     clientProps.put(SslConfigs.SSL_PROTOCOL_CONFIG, SimpleConfigurationReader.getValue(

--- a/mod-pubsub-server/src/main/java/org/folio/kafka/KafkaConfig.java
+++ b/mod-pubsub-server/src/main/java/org/folio/kafka/KafkaConfig.java
@@ -99,7 +99,7 @@ public class KafkaConfig {
     return envId;
   }
 
-  private void ensureSecurityProps(Map<String, String> clientProps) {  //NOSONAR
+  private void ensureSecurityProps(Map<String, String> clientProps) {
     clientProps.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, SimpleConfigurationReader.getValue(
       kafkaSecurityProtocolConfig, SpringKafkaProperties.KAFKA_SECURITY_PROTOCOL, KAFKA_SECURITY_PROTOCOL_DEFAULT));
     clientProps.put(SslConfigs.SSL_PROTOCOL_CONFIG, SimpleConfigurationReader.getValue(

--- a/mod-pubsub-server/src/main/java/org/folio/kafka/KafkaConfig.java
+++ b/mod-pubsub-server/src/main/java/org/folio/kafka/KafkaConfig.java
@@ -26,23 +26,23 @@ public class KafkaConfig {
   private int numberOfPartitions;
   @Value("${ENV:folio}")
   private String envId;
-  @Value("${security.protocol}")
+  @Value("${security.protocol:}")
   private String kafkaSecurityProtocolConfig;
-  @Value("${ssl.protocol}")
+  @Value("${ssl.protocol:}")
   private String kafkaSslProtocolConfig;
-  @Value("${ssl.key.password}")
+  @Value("${ssl.key.password:}")
   private String kafkaSslKeyPasswordConfig;
-  @Value("${ssl.truststore.location}")
+  @Value("${ssl.truststore.location:}")
   private String kafkaSslTruststoreLocationConfig;
-  @Value("${ssl.truststore.password}")
+  @Value("${ssl.truststore.password:}")
   private String kafkaSslTruststorePasswordConfig;
-  @Value("${ssl.truststore.type}")
+  @Value("${ssl.truststore.type:}")
   private String kafkaSslTruststoreTypeConfig;
-  @Value("${ssl.keystore.location}")
+  @Value("${ssl.keystore.location:}")
   private String kafkaSslKeystoreLocationConfig;
-  @Value("${ssl.keystore.password}")
+  @Value("${ssl.keystore.password:}")
   private String kafkaSslKeystorePasswordConfig;
-  @Value("${ssl.keystore.type}")
+  @Value("${ssl.keystore.type:}")
   private String kafkaSslKeystoreTypeConfig;
 
   public static final String KAFKA_SECURITY_PROTOCOL_DEFAULT = "PLAINTEXT";

--- a/mod-pubsub-server/src/main/java/org/folio/kafka/SpringKafkaProperties.java
+++ b/mod-pubsub-server/src/main/java/org/folio/kafka/SpringKafkaProperties.java
@@ -1,0 +1,26 @@
+package org.folio.kafka;
+
+public final class SpringKafkaProperties {
+
+  public static final String KAFKA_SECURITY_PROTOCOL = "spring.kafka.security.protocol";
+
+  public static final String KAFKA_SSL_PROTOCOL = "spring.kafka.ssl.protocol";
+
+  public static final String KAFKA_SSL_KEY_PASSWORD = "spring.kafka.ssl.key-password";
+
+  public static final String KAFKA_SSL_TRUSTSTORE_LOCATION = "spring.kafka.ssl.trust-store-location";
+
+  public static final String KAFKA_SSL_TRUSTSTORE_PASSWORD = "spring.kafka.ssl.trust-store-password";
+
+  public static final String KAFKA_SSL_TRUSTSTORE_TYPE = "spring.kafka.ssl.trust-store-type";
+
+  public static final String KAFKA_SSL_KEYSTORE_LOCATION = "spring.kafka.ssl.key-store-location";
+
+  public static final String KAFKA_SSL_KEYSTORE_PASSWORD = "spring.kafka.ssl.key-store-password";
+
+  public static final String KAFKA_SSL_KEYSTORE_TYPE = "spring.kafka.ssl.key-store-type";
+
+  private SpringKafkaProperties() {
+    throw new UnsupportedOperationException();
+  }
+}

--- a/mod-pubsub-server/src/main/java/org/folio/kafka/SpringKafkaProperties.java
+++ b/mod-pubsub-server/src/main/java/org/folio/kafka/SpringKafkaProperties.java
@@ -1,6 +1,6 @@
 package org.folio.kafka;
 
-public final class SpringKafkaProperties {
+public final class SpringKafkaProperties {//NOSONAR
 
   public static final String KAFKA_SECURITY_PROTOCOL = "spring.kafka.security.protocol";
 

--- a/mod-pubsub-server/src/main/java/org/folio/kafka/SpringKafkaProperties.java
+++ b/mod-pubsub-server/src/main/java/org/folio/kafka/SpringKafkaProperties.java
@@ -1,6 +1,6 @@
 package org.folio.kafka;
 
-public final class SpringKafkaProperties {  //NOSONAR
+public final class SpringKafkaProperties {
 
   public static final String KAFKA_SECURITY_PROTOCOL = "spring.kafka.security.protocol";
 

--- a/mod-pubsub-server/src/main/java/org/folio/kafka/SpringKafkaProperties.java
+++ b/mod-pubsub-server/src/main/java/org/folio/kafka/SpringKafkaProperties.java
@@ -1,6 +1,6 @@
 package org.folio.kafka;
 
-public final class SpringKafkaProperties {//NOSONAR
+public final class SpringKafkaProperties {  //NOSONAR
 
   public static final String KAFKA_SECURITY_PROTOCOL = "spring.kafka.security.protocol";
 

--- a/mod-pubsub-server/src/main/java/org/folio/rest/util/SimpleConfigurationReader.java
+++ b/mod-pubsub-server/src/main/java/org/folio/rest/util/SimpleConfigurationReader.java
@@ -1,0 +1,20 @@
+package org.folio.rest.util;
+
+import org.apache.commons.lang.StringUtils;
+
+/**
+ * Util for reading properties for system and spring configuration.
+ */
+public class SimpleConfigurationReader {
+  private SimpleConfigurationReader() {
+    super();
+  }
+
+  public static String getValue(String systemProperty, String kafkaProperty, String defValue) {
+    if (StringUtils.isBlank(systemProperty)) {
+      String value = System.getProperty(kafkaProperty, System.getenv(kafkaProperty));
+      return value != null ? value : defValue;
+    }
+    return systemProperty;
+  }
+}

--- a/mod-pubsub-server/src/test/java/org/folio/kafka/KafkaConfigTest.java
+++ b/mod-pubsub-server/src/test/java/org/folio/kafka/KafkaConfigTest.java
@@ -1,0 +1,32 @@
+package org.folio.kafka;
+
+import java.util.Map;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+
+public class KafkaConfigTest {
+
+  @Test
+  public void shouldReturnProducerProperties() {
+    Map<String, String> producerProps = new KafkaConfig().getProducerProps();
+
+    Assert.assertEquals("PLAINTEXT", producerProps.get("security.protocol"));
+    Assert.assertEquals("TLSv1.2", producerProps.get("ssl.protocol"));
+    Assert.assertEquals("JKS", producerProps.get("ssl.truststore.type"));
+    Assert.assertEquals("JKS", producerProps.get("ssl.keystore.type"));
+    Assert.assertNull(producerProps.get("ssl.keystore.password"));
+  }
+
+  @Test
+  public void shouldReturnConsumerProperties() {
+    Map<String, String> consumerProps = new KafkaConfig().getConsumerProps();
+
+    Assert.assertEquals("PLAINTEXT", consumerProps.get("security.protocol"));
+    Assert.assertEquals("TLSv1.2", consumerProps.get("ssl.protocol"));
+    Assert.assertEquals("JKS", consumerProps.get("ssl.truststore.type"));
+    Assert.assertEquals("JKS", consumerProps.get("ssl.keystore.type"));
+    Assert.assertNull(consumerProps.get("ssl.keystore.password"));
+  }
+}

--- a/mod-pubsub-server/src/test/java/org/folio/rest/util/SimpleConfigurationReaderTest.java
+++ b/mod-pubsub-server/src/test/java/org/folio/rest/util/SimpleConfigurationReaderTest.java
@@ -1,0 +1,31 @@
+package org.folio.rest.util;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class SimpleConfigurationReaderTest {
+
+  @Test
+  public void shouldReadValueFromSystemProperty() {
+    String expectedValue = "validProperty";
+    System.setProperty("test.props", expectedValue);
+    String actualValue = SimpleConfigurationReader.getValue("validProperty", "test.props", null);
+    Assert.assertEquals(expectedValue, actualValue);
+  }
+
+  @Test
+  public void shouldReturnSpringValueIfNoSysProperty() {
+    String expectedValue = "validProperty";
+    System.setProperty("test.props", expectedValue);
+    String actualValue = SimpleConfigurationReader.getValue(null, "test.props", null);
+    Assert.assertEquals(expectedValue, actualValue);
+  }
+
+  @Test
+  public void shouldReturnDefaultValueIfSysAndSpringPropertiesAreEmpty() {
+    String defaultValue = "default";
+    String actualValue = SimpleConfigurationReader.getValue(null, "test.props", "default");
+    Assert.assertEquals(defaultValue, actualValue);
+  }
+}
+

--- a/mod-pubsub-server/src/test/java/org/folio/rest/util/SimpleConfigurationReaderTest.java
+++ b/mod-pubsub-server/src/test/java/org/folio/rest/util/SimpleConfigurationReaderTest.java
@@ -24,7 +24,7 @@ public class SimpleConfigurationReaderTest {
   @Test
   public void shouldReturnDefaultValueIfSysAndSpringPropertiesAreEmpty() {
     String defaultValue = "default";
-    String actualValue = SimpleConfigurationReader.getValue(null, "test.props", "default");
+    String actualValue = SimpleConfigurationReader.getValue(null, "test2.props", "default");
     Assert.assertEquals(defaultValue, actualValue);
   }
 }


### PR DESCRIPTION
## Purpose
Increase security providing security properties for mod-pubsub.

## Approach
1.Check if sys property exists and applies to producer/consumer.
2. If not check if spring property exists and applies to producer/consumer.
3. If not, apply default (if default provided).

Tests added + NEWS updated.

## Learning
More info: https://issues.folio.org/browse/MODPUBSUB-182
