### PR TITLE
MODPUBSUB-186 Provide 'ssl.endpoint.identification.algorithm' property

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,9 @@
 ## 2021-XX-XX v2.4.0-SNAPSHOT
+* [MODPUBSUB-186](https://issues.folio.org/browse/MODPUBSUB-186) Provide 'ssl.endpoint.identification.algorithm' property
+
+## 2021-06-17 v2.3.1
 * [MODPUBSUB-181](https://issues.folio.org/browse/MODPUBSUB-181) mod-source-record-manager unable to create Kafka topics if tenant ID doesn't match \w{4,}
-* [MODPUBSUB-182](https://issues.folio.org/browse/MODPUBSUB-182) Provide properties for Kafka security in mod-pubsub.
+* [MODPUBSUB-182](https://issues.folio.org/browse/MODPUBSUB-182) Provide properties for Kafka security in mod-pubsub
 
 ## 2021-06-10 v2.3.0
 * [MODPUBSUB-179](https://issues.folio.org/browse/MODPUBSUB-179) Use local PomReader to retrieve module name and version
@@ -23,6 +26,9 @@
 * [MODINV-373](https://issues.folio.org/browse/MODINV-373) Ensure exactly once processing for interaction via Kafka
 * [MODPUBSUB-152](https://issues.folio.org/browse/MODPUBSUB-152) Fix module registration failure when MessagingDescriptor contains no publications
 * [MODPUBSUB-150](https://issues.folio.org/browse/MODPUBSUB-150) Use "replaces" for deprecated permissions replaced by a new permission
+
+## 2021-06-17 v2.0.8
+* [MODPUBSUB-181](https://issues.folio.org/browse/MODPUBSUB-181) Allow creating Kafka topics if tenant ID doesn't match \w{4,}
 
 ## 2021-05-17 v2.0.7
 * [MODPUBSUB-166](https://issues.folio.org/browse/MODPUBSUB-166) Fix memory leak in PubSubClientUtils

--- a/folio-kafka-wrapper/src/main/java/org/folio/kafka/KafkaConfig.java
+++ b/folio-kafka-wrapper/src/main/java/org/folio/kafka/KafkaConfig.java
@@ -57,6 +57,8 @@ public class KafkaConfig {
   public static final String KAFKA_SSL_KEYSTORE_TYPE_CONFIG = "ssl.keystore.type";
   public static final String KAFKA_SSL_KEYSTORE_TYPE_DEFAULT = "JKS";
 
+  public static final String KAFKA_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG = "ssl.endpoint.identification.algorithm";
+
   private static final String KAFKA_CACHE_TOPIC_PROPERTY = "kafkacache.topic";
   private static final String KAFKA_CACHE_TOPIC_PROPERTY_DEFAULT = "events_cache";
 
@@ -130,6 +132,8 @@ public class KafkaConfig {
       List.of(KAFKA_SSL_KEYSTORE_PASSWORD_CONFIG, SpringKafkaProperties.KAFKA_SSL_KEYSTORE_PASSWORD), null));
     clientProps.put(SslConfigs.SSL_KEYSTORE_TYPE_CONFIG, SimpleConfigurationReader.getValue(
       List.of(KAFKA_SSL_KEYSTORE_TYPE_CONFIG, SpringKafkaProperties.KAFKA_SSL_KEYSTORE_TYPE), KAFKA_SSL_KEYSTORE_TYPE_DEFAULT));
+    clientProps.put(SslConfigs.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG, SimpleConfigurationReader.getValue(
+      List.of(KAFKA_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG, SpringKafkaProperties.KAFKA_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM), null));
   }
 
 }

--- a/folio-kafka-wrapper/src/main/java/org/folio/kafka/SpringKafkaProperties.java
+++ b/folio-kafka-wrapper/src/main/java/org/folio/kafka/SpringKafkaProperties.java
@@ -28,6 +28,8 @@ public final class SpringKafkaProperties {
 
   public static final String KAFKA_SSL_KEYSTORE_TYPE = "spring.kafka.ssl.key-store-type";
 
+  public static final String KAFKA_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM = "spring.kafka.properties.ssl.endpoint.identification.algorithm";
+
   private SpringKafkaProperties() {
     throw new UnsupportedOperationException();
   }

--- a/mod-pubsub-server/src/main/java/org/folio/kafka/KafkaConfig.java
+++ b/mod-pubsub-server/src/main/java/org/folio/kafka/KafkaConfig.java
@@ -44,6 +44,8 @@ public class KafkaConfig {
   private String kafkaSslKeystorePasswordConfig;
   @Value("${ssl.keystore.type:}")
   private String kafkaSslKeystoreTypeConfig;
+  @Value("${ssl.endpoint.identification.algorithm:}")
+  private String kafkaSslEndpointIdentificationAlgorithm;
 
   public static final String KAFKA_SECURITY_PROTOCOL_DEFAULT = "PLAINTEXT";
   public static final String KAFKA_SSL_PROTOCOL_DEFAULT = "TLSv1.2";
@@ -118,5 +120,7 @@ public class KafkaConfig {
       kafkaSslKeystorePasswordConfig, SpringKafkaProperties.KAFKA_SSL_KEYSTORE_PASSWORD, null));
     clientProps.put(SslConfigs.SSL_KEYSTORE_TYPE_CONFIG, SimpleConfigurationReader.getValue(
       kafkaSslKeystoreTypeConfig, SpringKafkaProperties.KAFKA_SSL_KEYSTORE_TYPE, KAFKA_SSL_KEYSTORE_TYPE_DEFAULT));
+    clientProps.put(SslConfigs.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG, SimpleConfigurationReader.getValue(
+      kafkaSslEndpointIdentificationAlgorithm, SpringKafkaProperties.KAFKA_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM, null));
   }
 }

--- a/mod-pubsub-server/src/main/java/org/folio/kafka/SpringKafkaProperties.java
+++ b/mod-pubsub-server/src/main/java/org/folio/kafka/SpringKafkaProperties.java
@@ -20,6 +20,8 @@ public final class SpringKafkaProperties {
 
   public static final String KAFKA_SSL_KEYSTORE_TYPE = "spring.kafka.ssl.key-store-type";
 
+  public static final String KAFKA_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM = "spring.kafka.properties.ssl.endpoint.identification.algorithm";
+
   private SpringKafkaProperties() {
     throw new UnsupportedOperationException();
   }


### PR DESCRIPTION
## Purpose
**ssl.endpoint.identification.algorithm** option has to be set to null regarding [Kafka docs](https://docs.confluent.io/4.0.0/kafka/authentication_ssl.html#optional-settings) to allow SSL connection using DNS CNAME

## Approach
Add **ssl.endpoint.identification.algorithm** property

## Learning
https://docs.confluent.io/4.0.0/kafka/authentication_ssl.html#optional-settings