### PR TITLE
MODPUBSUB-187 Add support for max.request.size configuration for Kafk…

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 ## 2021-XX-XX v2.4.0-SNAPSHOT
 * [MODPUBSUB-186](https://issues.folio.org/browse/MODPUBSUB-186) Provide 'ssl.endpoint.identification.algorithm' property
+* [MODPUBSUB-187](https://issues.folio.org/browse/MODPUBSUB-187) Add support for max.request.size configuration for Kafka messages
 
 ## 2021-06-17 v2.3.1
 * [MODPUBSUB-181](https://issues.folio.org/browse/MODPUBSUB-181) mod-source-record-manager unable to create Kafka topics if tenant ID doesn't match \w{4,}

--- a/folio-kafka-wrapper/src/main/java/org/folio/kafka/KafkaConfig.java
+++ b/folio-kafka-wrapper/src/main/java/org/folio/kafka/KafkaConfig.java
@@ -65,6 +65,7 @@ public class KafkaConfig {
   private final String okapiUrl;
   private final int replicationFactor;
   private final String envId;
+  private final int maxRequestSize;
 
   public Map<String, String> getProducerProps() {
     Map<String, String> producerProps = new HashMap<>();
@@ -72,6 +73,7 @@ public class KafkaConfig {
     producerProps.put(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, "true");
     producerProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.StringSerializer");
     producerProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.StringSerializer");
+    producerProps.put(ProducerConfig.MAX_REQUEST_SIZE_CONFIG, String.valueOf(getMaxRequestSize()));
     ensureSecurityProps(producerProps);
     return producerProps;
   }

--- a/mod-pubsub-server/src/main/java/org/folio/kafka/KafkaConfig.java
+++ b/mod-pubsub-server/src/main/java/org/folio/kafka/KafkaConfig.java
@@ -26,6 +26,8 @@ public class KafkaConfig {
   private int numberOfPartitions;
   @Value("${ENV:folio}")
   private String envId;
+  @Value("${MAX_REQUEST_SIZE:1048576}")
+  private int maxRequestSize;
   @Value("${security.protocol:}")
   private String kafkaSecurityProtocolConfig;
   @Value("${ssl.protocol:}")
@@ -68,6 +70,7 @@ public class KafkaConfig {
     producerProps.put(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, "true");
     producerProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.StringSerializer");
     producerProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.StringSerializer");
+    producerProps.put(ProducerConfig.MAX_REQUEST_SIZE_CONFIG, String.valueOf(getMaxRequestSize()));
     ensureSecurityProps(producerProps);
     return producerProps;
   }
@@ -97,6 +100,10 @@ public class KafkaConfig {
 
   public String getEnvId() {
     return envId;
+  }
+
+  public int getMaxRequestSize() {
+    return maxRequestSize;
   }
 
   private void ensureSecurityProps(Map<String, String> clientProps) {


### PR DESCRIPTION
…a messages

## Purpose
When attempting to import a file the import job does not complete due to the following error
org.apache.kafka.common.errors.RecordTooLargeException: The message is 1287037 bytes when serialized which is larger than 1048576, which is the value of the max.request.size configuration.

## Approach
Add support for max.request.size configuration for Kafka messages

## Learning
https://docs.confluent.io/platform/current/installation/configuration/producer-configs.html#producerconfigs_max.request.size