### PR TITLE
MODPUBSUB-192 Check if max.request.size is set before putting it as producer props

### DIFF
--- a/folio-kafka-wrapper/src/main/java/org/folio/kafka/KafkaConfig.java
+++ b/folio-kafka-wrapper/src/main/java/org/folio/kafka/KafkaConfig.java
@@ -75,7 +75,9 @@ public class KafkaConfig {
     producerProps.put(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, "true");
     producerProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.StringSerializer");
     producerProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.StringSerializer");
-    producerProps.put(ProducerConfig.MAX_REQUEST_SIZE_CONFIG, String.valueOf(getMaxRequestSize()));
+    if (getMaxRequestSize() > 0) {
+      producerProps.put(ProducerConfig.MAX_REQUEST_SIZE_CONFIG, String.valueOf(getMaxRequestSize()));
+    }
     ensureSecurityProps(producerProps);
     return producerProps;
   }


### PR DESCRIPTION
## Purpose
If max.request.size is not set as ENV variable in a module that uses folio-kafka-wrapper, it's value is initialised to 0 and put into Producer props, which overwrites default Kafka values

## Approach
Check if max.request.size is set before putting to Producer props, if not - leave it to Kafka default 
