### PR TITLE
WebClient factory - take two MODSPUBSUB-201

### DIFF
--- a/mod-pubsub-server/src/main/java/org/folio/rest/util/RestUtil.java
+++ b/mod-pubsub-server/src/main/java/org/folio/rest/util/RestUtil.java
@@ -5,10 +5,7 @@ import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Promise;
-import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
-import io.vertx.core.http.HttpClient;
-import io.vertx.core.http.HttpClientOptions;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.client.HttpRequest;
@@ -82,7 +79,7 @@ public final class RestUtil {
     try {
       Map<String, String> headers = params.getHeaders();
       String requestUrl = params.getOkapiUrl() + url;
-      WebClient client = WebClient.wrap(getHttpClient(params));
+      WebClient client = params.getWebClient();
 
       HttpRequest<Buffer> request = client.requestAbs(method, requestUrl);
       if (headers != null) {
@@ -120,18 +117,5 @@ public final class RestUtil {
         promise.fail(ar.cause());
       }
     };
-  }
-
-  /**
-   * Prepare HttpClient from OkapiConnection params
-   *
-   * @param params - Okapi connection params
-   * @return - Vertx Http Client
-   */
-  private static HttpClient getHttpClient(OkapiConnectionParams params) {
-    HttpClientOptions options = new HttpClientOptions();
-    options.setConnectTimeout(params.getTimeout());
-    options.setIdleTimeout(params.getTimeout());
-    return params.getVertx() != null ? params.getVertx().createHttpClient(options) : Vertx.currentContext().owner().createHttpClient(options);
   }
 }

--- a/mod-pubsub-server/src/test/java/org/folio/services/impl/ConsumerServiceUnitTest.java
+++ b/mod-pubsub-server/src/test/java/org/folio/services/impl/ConsumerServiceUnitTest.java
@@ -191,7 +191,6 @@ public class ConsumerServiceUnitTest {
     params.setOkapiUrl(headers.getOrDefault("x-okapi-url", "localhost"));
     params.setTenantId(headers.getOrDefault("x-okapi-tenant", TENANT));
     params.setToken(headers.getOrDefault("x-okapi-token", TOKEN));
-    params.setTimeout(2000);
 
     Set<MessagingModule> messagingModuleList = new HashSet<>();
     messagingModuleList.add(new MessagingModule()
@@ -241,7 +240,6 @@ public class ConsumerServiceUnitTest {
     params.setOkapiUrl(headers.getOrDefault("x-okapi-url", "localhost"));
     params.setTenantId(headers.getOrDefault("x-okapi-tenant", TENANT));
     params.setToken(headers.getOrDefault("x-okapi-token", TOKEN));
-    params.setTimeout(2000);
 
     Set<MessagingModule> messagingModuleList = new HashSet<>();
     messagingModuleList.add(new MessagingModule()

--- a/mod-pubsub-server/src/test/java/org/folio/services/impl/SecurityManagerTest.java
+++ b/mod-pubsub-server/src/test/java/org/folio/services/impl/SecurityManagerTest.java
@@ -112,8 +112,7 @@ public class SecurityManagerTest {
     stubFor(post(LOGIN_URL)
       .willReturn(created().withHeader(OKAPI_HEADER_TOKEN, pubSubToken)));
 
-    OkapiConnectionParams params = new OkapiConnectionParams();
-    params.setVertx(vertx);
+    OkapiConnectionParams params = new OkapiConnectionParams(vertx);
     params.setOkapiUrl(headers.get(OKAPI_URL_HEADER));
     params.setTenantId(TENANT);
     params.setToken(TOKEN);


### PR DESCRIPTION
## Purpose

Fix socket leak https://issues.folio.org/browse/MODPUBSUB-201

## Approach

Construct one WebClient per Vert.x instance. Make that logic in OkapiConnectionParams.

A slightly different approach from first PR https://github.com/folio-org/mod-pubsub/pull/174

