### PR TITLE
Add perms.users.assign.immutable MODPUBSUB-209

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -202,7 +202,8 @@
             "users.item.post",
             "users.item.put",
             "login.item.post",
-            "perms.users.item.post"
+            "perms.users.item.post",
+            "perms.users.assign.immutable"
           ]
         },
         {


### PR DESCRIPTION
mod-permissions 6.0.0 has an extra security check to avoid general users assigning
arbitrary permissions.

https://issues.folio.org/browse/MODPUBSUB-209