### PR TITLE
MODPUBSUB-212: Replace Future<Boolean> by Future<Void> SecurityManager

### DIFF
--- a/mod-pubsub-server/src/main/java/org/folio/rest/impl/ModTenantAPI.java
+++ b/mod-pubsub-server/src/main/java/org/folio/rest/impl/ModTenantAPI.java
@@ -30,7 +30,7 @@ public class ModTenantAPI extends TenantAPI {
         LiquibaseUtil.initializeSchemaForTenant(vertx, tenantId);
         OkapiConnectionParams params = new OkapiConnectionParams(headers, vertx);
         return securityManager.createPubSubUser(params)
-          .compose(ar -> securityManager.loginPubSubUser(params)).map(num);
+          .compose(ar -> securityManager.getJWTToken(params)).map(num);
       });
   }
 }

--- a/mod-pubsub-server/src/main/java/org/folio/services/SecurityManager.java
+++ b/mod-pubsub-server/src/main/java/org/folio/services/SecurityManager.java
@@ -10,15 +10,7 @@ import org.folio.rest.util.OkapiConnectionParams;
 public interface SecurityManager {
 
   /**
-   * Log in system user and save obtained token in the vertx context
-   *
-   * @param params okapi connection params
-   * @return future with true if succeeded
-   */
-  Future<Boolean> loginPubSubUser(OkapiConnectionParams params);
-
-  /**
-   * Get JWT token for system user
+   * Get JWT token, log in system user if needed
    *
    * @param params okapi connection params
    * @return future with token
@@ -29,7 +21,6 @@ public interface SecurityManager {
    * Creates new system user if it doesn't exist and assigns all necessary permissions
    *
    * @param params okapi connection params
-   * @return future with true if succeeded
    */
-  Future<Boolean> createPubSubUser(OkapiConnectionParams params);
+  Future<Void> createPubSubUser(OkapiConnectionParams params);
 }

--- a/mod-pubsub-server/src/main/java/org/folio/services/impl/KafkaConsumerServiceImpl.java
+++ b/mod-pubsub-server/src/main/java/org/folio/services/impl/KafkaConsumerServiceImpl.java
@@ -178,8 +178,7 @@ public class KafkaConsumerServiceImpl implements ConsumerService {
   private void retryDelivery(Event event, MessagingModule subscriber, OkapiConnectionParams params, Map<MessagingModule, AtomicInteger> retry) {
     if (retry.get(subscriber).get() <= RETRY_NUMBER) {
       LOGGER.info("Retry to deliver event {} event with id '{}' to {}", event.getEventType(), event.getId(), subscriber.getSubscriberCallback());
-      securityManager.loginPubSubUser(params)
-        .compose(v -> securityManager.getJWTToken(params))
+      securityManager.getJWTToken(params)
         .onSuccess(params::setToken)
         .compose(v -> doRequest(params, subscriber.getSubscriberCallback(), HttpMethod.POST, event.getEventPayload())
           .onComplete(getEventDeliveredHandler(event, params.getTenantId(), subscriber, params, retry)));

--- a/mod-pubsub-server/src/main/java/org/folio/services/impl/SecurityManagerImpl.java
+++ b/mod-pubsub-server/src/main/java/org/folio/services/impl/SecurityManagerImpl.java
@@ -9,7 +9,6 @@ import io.vertx.core.http.HttpMethod;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import org.apache.commons.collections4.CollectionUtils;
-import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -64,12 +63,12 @@ public class SecurityManagerImpl implements SecurityManager {
   }
 
   @Override
-  public Future<Boolean> loginPubSubUser(OkapiConnectionParams params) {
+  public Future<String> getJWTToken(OkapiConnectionParams params) {
     params.setToken(EMPTY);
 
-    String token = cache.getToken(params.getTenantId());
-    if (!StringUtils.isEmpty(token)) {
-      return Future.succeededFuture(true);
+    String cachedToken = cache.getToken(params.getTenantId());
+    if (!StringUtils.isEmpty(cachedToken)) {
+      return Future.succeededFuture(cachedToken);
     }
 
     return Future.succeededFuture(systemUserConfig.getUserCredentialsJson())
@@ -77,31 +76,19 @@ public class SecurityManagerImpl implements SecurityManager {
       .compose(response -> {
         if (response.getCode() == HttpStatus.HTTP_CREATED.toInt()) {
           LOGGER.info("Logged in {} user", systemUserConfig.getName());
-          cache.addToken(params.getTenantId(), response.getResponse().getHeader(OKAPI_TOKEN_HEADER));
-          return Future.succeededFuture(true);
+          String token = response.getResponse().getHeader(OKAPI_TOKEN_HEADER);
+          cache.addToken(params.getTenantId(), token);
+          return Future.succeededFuture(token);
         }
-        LOGGER.error("{} user was not logged in, received status {}", systemUserConfig.getName(),
-          response.getCode());
-        return Future.succeededFuture(false);
+        String message = String.format("%s user was not logged in, received status %d",
+            systemUserConfig.getName(), response.getCode());
+        LOGGER.error(message);
+        return Future.failedFuture(message);
       });
   }
 
   @Override
-  public Future<String> getJWTToken(OkapiConnectionParams params) {
-    String token = cache.getToken(params.getTenantId());
-    if (StringUtils.isEmpty(token)) {
-      return loginPubSubUser(params).compose(isLoggedIn -> {
-        if (BooleanUtils.isTrue(isLoggedIn)) {
-          return Future.succeededFuture(cache.getToken(params.getTenantId()));
-        }
-        return Future.failedFuture(format("Failed %s user log in", systemUserConfig.getName()));
-      });
-    }
-    return Future.succeededFuture(token);
-  }
-
-  @Override
-  public Future<Boolean> createPubSubUser(OkapiConnectionParams params) {
+  public Future<Void> createPubSubUser(OkapiConnectionParams params) {
     return existsPubSubUser(params)
       .compose(user -> {
         if (user != null) {
@@ -206,11 +193,12 @@ public class SecurityManagerImpl implements SecurityManager {
       });
   }
 
-  private Future<Boolean> assignPermissions(String userId, OkapiConnectionParams params) {
+  private Future<Void> assignPermissions(String userId, OkapiConnectionParams params) {
     List<String> permissions = readPermissionsFromResource(PERMISSIONS_FILE_PATH);
     if (CollectionUtils.isEmpty(permissions)) {
-      LOGGER.info("No permissions found to assign to {} user", systemUserConfig.getName());
-      return Future.succeededFuture(false);
+      String message = String.format("No permissions found to assign to %s user", systemUserConfig.getName());
+      LOGGER.info(message);
+      return Future.failedFuture(message);
     }
     JsonObject requestBody = new JsonObject()
       .put("id", UUID.randomUUID().toString())
@@ -218,48 +206,45 @@ public class SecurityManagerImpl implements SecurityManager {
       .put("permissions", new JsonArray(permissions));
     return doRequest(params, PERMISSIONS_URL, HttpMethod.POST, requestBody.encode())
       .compose(response -> {
-        Promise<Boolean> promise = Promise.promise();
         if (response.getCode() == HttpStatus.HTTP_CREATED.toInt()) {
           LOGGER.info("Added permissions [{}] for {} user", StringUtils.join(permissions, ","),
             systemUserConfig.getName());
-          promise.complete(true);
+          return Future.succeededFuture();
         } else {
           String errorMessage = format("Failed to add permissions for %s user. Received status code %s",
             systemUserConfig.getName(), response.getCode());
           LOGGER.error(errorMessage);
-          promise.fail(errorMessage);
+          return Future.failedFuture(errorMessage);
         }
-        return promise.future();
       });
   }
 
-  private Future<Boolean> addPermissions(String userId, OkapiConnectionParams params) {
+  private Future<Void> addPermissions(String userId, OkapiConnectionParams params) {
     List<String> permissions = readPermissionsFromResource(PERMISSIONS_FILE_PATH);
     if (CollectionUtils.isEmpty(permissions)) {
-      LOGGER.info("No permissions found to add for {} user", systemUserConfig.getName());
-      return Future.succeededFuture(false);
+      String message = String.format("No permissions found to add for %s user", systemUserConfig.getName());
+      LOGGER.info(message);
+      return Future.failedFuture(message);
     }
-    List<Future<?>> futures = new ArrayList<>();
+    List<Future<Void>> futures = new ArrayList<>();
     String permUrl = PERMISSIONS_URL + "/" + userId + "/permissions?indexField=userId";
     permissions.forEach(permission -> {
       JsonObject requestBody = new JsonObject()
         .put("permissionName", permission);
       futures.add(doRequest(params, permUrl, HttpMethod.POST, requestBody.encode())
         .compose(response -> {
-          Promise<Boolean> promise = Promise.promise();
           if (response.getCode() == HttpStatus.HTTP_OK.toInt()) {
             LOGGER.info("Added permission {} for {} user", permission, systemUserConfig.getName());
-            promise.complete(true);
+            return Future.succeededFuture();
           } else {
             String errorMessage = format("Failed to add permission %s for %s user. Received status code %s",
               permission, systemUserConfig.getName(), response.getCode());
             LOGGER.error(errorMessage);
-            promise.complete(false);
+            return Future.failedFuture(errorMessage);
           }
-          return promise.future();
         }));
     });
-    return GenericCompositeFuture.all(futures).map(true);
+    return GenericCompositeFuture.all(futures).mapEmpty();
   }
 
   private List<String> readPermissionsFromResource(String path) {

--- a/mod-pubsub-server/src/main/java/org/folio/services/impl/SecurityManagerImpl.java
+++ b/mod-pubsub-server/src/main/java/org/folio/services/impl/SecurityManagerImpl.java
@@ -209,7 +209,7 @@ public class SecurityManagerImpl implements SecurityManager {
           return Future.succeededFuture();
         } else {
           String errorMessage = format("Failed to add permissions %s for %s user. Received status code %s: %s",
-            StringUtils.join(permissions, ","), systemUserConfig.getName(), response.getCode(),
+            StringUtils.join(PERMISSIONS, ","), systemUserConfig.getName(), response.getCode(),
             response.getBody());
           LOGGER.error(errorMessage);
           return Future.failedFuture(errorMessage);

--- a/mod-pubsub-server/src/test/java/org/folio/rest/impl/ModTenantApiTest.java
+++ b/mod-pubsub-server/src/test/java/org/folio/rest/impl/ModTenantApiTest.java
@@ -6,6 +6,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.okJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.put;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
@@ -60,7 +61,9 @@ public class ModTenantApiTest extends AbstractRestTest {
     wireMockRule.stubFor(get(GET_PUBSUB_USER_URL)
       .willReturn(okJson(userCollection.toString())));
     wireMockRule.stubFor(put(userByIdUrl(user.getId()))
-      .willReturn(aResponse().withStatus(204)));
+        .willReturn(aResponse().withStatus(204)));
+    wireMockRule.stubFor(post(permissionsUrl(user.getId()))
+        .willReturn(aResponse().withStatus(200)));
 
     getTenant();
 
@@ -123,6 +126,10 @@ public class ModTenantApiTest extends AbstractRestTest {
 
   private String userByIdUrl(String id) {
     return USERS_URL + "/" + id;
+  }
+
+  private String permissionsUrl(String id) {
+    return "/perms/users/" + id + "/permissions?indexField=userId";
   }
 
   private String mockOkapiUrl() {

--- a/mod-pubsub-server/src/test/java/org/folio/services/impl/ConsumerServiceUnitTest.java
+++ b/mod-pubsub-server/src/test/java/org/folio/services/impl/ConsumerServiceUnitTest.java
@@ -78,7 +78,6 @@ public class ConsumerServiceUnitTest {
   public void setUp() {
     MockitoAnnotations.initMocks(this);
     when(securityManager.getJWTToken(any(OkapiConnectionParams.class))).thenReturn(Future.succeededFuture(TOKEN));
-    when(securityManager.loginPubSubUser(any(OkapiConnectionParams.class))).thenReturn(Future.succeededFuture(true));
 
     headers.put(OKAPI_URL_HEADER, "http://localhost:" + mockServer.port());
     headers.put(OKAPI_TENANT_HEADER, TENANT);

--- a/mod-pubsub-server/src/test/java/org/folio/services/impl/SecurityManagerTest.java
+++ b/mod-pubsub-server/src/test/java/org/folio/services/impl/SecurityManagerTest.java
@@ -119,8 +119,7 @@ public class SecurityManagerTest {
     params.setTenantId(TENANT);
     params.setToken(TOKEN);
 
-    Future<String> future = securityManager.loginPubSubUser(params)
-      .compose(ar -> securityManager.getJWTToken(params));
+    Future<String> future = securityManager.getJWTToken(params);
 
     future.onComplete(ar -> {
       context.assertTrue(ar.succeeded());
@@ -147,11 +146,9 @@ public class SecurityManagerTest {
 
     OkapiConnectionParams params = new OkapiConnectionParams(headers, vertx);
 
-    Future<Boolean> future = securityManager.createPubSubUser(params);
+    Future<Void> future = securityManager.createPubSubUser(params);
 
     future.map(ar -> {
-      assertTrue(ar);
-
       List<LoggedRequest> requests = findAll(RequestPatternBuilder.allRequests());
       assertEquals(2, requests.size());
 
@@ -183,11 +180,9 @@ public class SecurityManagerTest {
 
     OkapiConnectionParams params = new OkapiConnectionParams(headers, vertx);
 
-    Future<Boolean> future = securityManager.createPubSubUser(params);
+    Future<Void> future = securityManager.createPubSubUser(params);
 
     future.map(ar -> {
-      assertTrue(ar);
-
       List<LoggedRequest> requests = findAll(RequestPatternBuilder.allRequests());
       assertEquals(4, requests.size());
 
@@ -258,11 +253,9 @@ public class SecurityManagerTest {
 
     OkapiConnectionParams params = new OkapiConnectionParams(headers, vertx);
 
-    Future<Boolean> future = securityManager.createPubSubUser(params);
+    Future<Void> future = securityManager.createPubSubUser(params);
 
     future.map(ar -> {
-      assertTrue(ar);
-
       final List<LoggedRequest> requests = findAll(RequestPatternBuilder.allRequests());
       assertEquals(3, requests.size());
 
@@ -292,11 +285,9 @@ public class SecurityManagerTest {
 
     OkapiConnectionParams params = new OkapiConnectionParams(headers, vertx);
 
-    Future<Boolean> future = securityManager.createPubSubUser(params);
+    Future<Void> future = securityManager.createPubSubUser(params);
 
     future.map(ar -> {
-      assertTrue(ar);
-
       final List<LoggedRequest> requests = findAll(RequestPatternBuilder.allRequests());
       assertEquals(2, requests.size());
 

--- a/mod-pubsub-server/src/test/java/org/folio/services/impl/SecurityManagerTest.java
+++ b/mod-pubsub-server/src/test/java/org/folio/services/impl/SecurityManagerTest.java
@@ -27,6 +27,7 @@ import static org.mockito.Mockito.when;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.NoSuchElementException;
 import java.util.UUID;
 
 import org.folio.dao.MessagingModuleDao;
@@ -321,6 +322,11 @@ public class SecurityManagerTest {
       assertEquals("Failed to add permissions for test-pubsub-username user. Received status code 403",
         x.getMessage())
     ));
+  }
+
+  @Test(expected = NoSuchElementException.class)
+  public void shouldFailReadingPermissionsOnEmptyPermissionsFile() {
+    SecurityManagerImpl.readPermissionsFromResource("permissions/emptyFile");
   }
 
   private void verifyUser(LoggedRequest loggedRequest) {


### PR DESCRIPTION
Future<Boolean> is used with true indicating success and false indicating failure. This results in two ways how a failure can be propagated: As a failing Future, or as a succeeding Future returning false. This results in bloated code and is error-prone.

The idiomatic way is to only use the built-in success/failure indicator of the Future and to use Void as the type: `Future<Void>`.

This reveals that SecurityManagerImpl#addPermissions and #assignPermissions don't properly propagate failures.
ModTenantApiTest#shouldLoginWithEnvVarCredentials was adopted accordingly.

Switching from `Future<Boolean>` to `Future<Void>` also allowed to merge SecurityManager#loginPubSubUser and #getJWTToken.

Lessons learned:
Replacing `Future<Boolean>` by `Future<Void>` results in less code and uncovers bugs.