### PR TITLE
MODPUBSUB-213: Replace Future<Boolean> in MessagingModuleDao

### DIFF
--- a/mod-pubsub-server/src/main/java/org/folio/dao/MessagingModuleDao.java
+++ b/mod-pubsub-server/src/main/java/org/folio/dao/MessagingModuleDao.java
@@ -29,20 +29,12 @@ public interface MessagingModuleDao {
   Future<List<MessagingModule>> save(List<MessagingModule> messagingModules);
 
   /**
-   * Deletes {@link MessagingModule} by id
-   *
-   * @param id messagingModule id
-   * @return future with true if succeeded
-   */
-  Future<Boolean> delete(String id);
-
-  /**
    * Deletes {@link MessagingModule} matching filter criteria
    *
    * @param filter messagingModule filter
-   * @return future with true if succeeded
+   * @return succeeded Future if deleted or not found
    */
-  Future<Boolean> delete(MessagingModuleFilter filter);
+  Future<Void> delete(MessagingModuleFilter filter);
 
   /**
    * Gets all registered {@link MessagingModule}

--- a/mod-pubsub-server/src/main/java/org/folio/dao/impl/MessagingModuleDaoImpl.java
+++ b/mod-pubsub-server/src/main/java/org/folio/dao/impl/MessagingModuleDaoImpl.java
@@ -104,19 +104,9 @@ public class MessagingModuleDaoImpl implements MessagingModuleDao {
   }
 
   @Override
-  public Future<Boolean> delete(String id) {
-    Promise<RowSet<Row>> promise = Promise.promise();
-    String query = format(DELETE_BY_ID_SQL, MODULE_SCHEMA, TABLE_NAME);
-    pgClientFactory.getInstance().execute(query, Tuple.of(UUID.fromString(id)), promise);
-    return promise.future().map(updateResult -> updateResult.rowCount() == 1);
-  }
-
-  @Override
-  public Future<Boolean> delete(MessagingModuleFilter filter) {
-    Promise<RowSet<Row>> promise = Promise.promise();
+  public Future<Void> delete(MessagingModuleFilter filter) {
     String query = format(DELETE_BY_SQL, MODULE_SCHEMA, TABLE_NAME, buildWhereClause(filter));
-    pgClientFactory.getInstance().execute(query, promise);
-    return promise.future().map(updateResult -> updateResult.rowCount() == 1);
+    return pgClientFactory.getInstance().execute(query).mapEmpty();
   }
 
   @Override

--- a/mod-pubsub-server/src/main/java/org/folio/services/MessagingModuleService.java
+++ b/mod-pubsub-server/src/main/java/org/folio/services/MessagingModuleService.java
@@ -56,9 +56,8 @@ public interface MessagingModuleService {
    * Deletes module matching filter criteria
    *
    * @param filter MessagingModule filter
-   * @return future with true if succeeded
    */
-  Future<Boolean> delete(MessagingModuleFilter filter);
+  Future<Void> delete(MessagingModuleFilter filter);
 
   /**
    * Searches for MessagingModules matching filter criteria

--- a/mod-pubsub-server/src/main/java/org/folio/services/impl/MessagingModuleServiceImpl.java
+++ b/mod-pubsub-server/src/main/java/org/folio/services/impl/MessagingModuleServiceImpl.java
@@ -143,7 +143,7 @@ public class MessagingModuleServiceImpl implements MessagingModuleService {
   }
 
   @Override
-  public Future<Boolean> delete(MessagingModuleFilter filter) {
+  public Future<Void> delete(MessagingModuleFilter filter) {
     return messagingModuleDao.delete(filter)
       .onSuccess(ar -> cache.invalidate());
   }

--- a/mod-pubsub-server/src/test/java/org/folio/dao/impl/MessagingModuleDaoImplUnitTest.java
+++ b/mod-pubsub-server/src/test/java/org/folio/dao/impl/MessagingModuleDaoImplUnitTest.java
@@ -1,19 +1,12 @@
 package org.folio.dao.impl;
 
-import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
-import io.vertx.core.Handler;
-import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
-import io.vertx.sqlclient.Row;
-import io.vertx.sqlclient.RowSet;
-import io.vertx.sqlclient.impl.ArrayTuple;
 import org.folio.dao.PostgresClientFactory;
-import org.folio.rest.jaxrs.model.MessagingModule;
 import org.folio.rest.persist.PostgresClient;
 import org.folio.rest.persist.helpers.LocalRowSet;
-import org.junit.Assert;
+import org.folio.rest.util.MessagingModuleFilter;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -21,19 +14,12 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
-import java.util.UUID;
-
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @RunWith(VertxUnitRunner.class)
 public class MessagingModuleDaoImplUnitTest {
-
-  private MessagingModule messagingModule = new MessagingModule()
-    .withId(UUID.randomUUID().toString());
 
   @Mock
   private PostgresClientFactory postgresClientFactory;
@@ -51,50 +37,26 @@ public class MessagingModuleDaoImplUnitTest {
       .thenReturn(pgClient);
   }
 
-  @Test
-  public void shouldReturnFutureWithTrueOnSuccessfulDeletionById(TestContext context) {
+  private void shouldSucceedOnDelete(TestContext context, int rowCount) {
     // given
-    Async async = context.async();
-    int updatedRowsNumber = 1;
-    RowSet<Row> updateResult = new LocalRowSet(updatedRowsNumber);
-
-    doAnswer(invocation -> {
-      Handler<AsyncResult<RowSet<Row>>> handler = invocation.getArgument(2);
-      handler.handle(Future.succeededFuture(updateResult));
-      return updateResult;
-    })
-      .when(pgClient).execute(anyString(), any(ArrayTuple.class), any(Handler.class));
+    when(pgClient.execute(anyString()))
+        .thenReturn(Future.succeededFuture(new LocalRowSet(rowCount)));
     // when
-    messagingModuleDao.delete(messagingModule.getId())
-      // then
-      .onComplete(ar -> {
-        Assert.assertTrue(ar.succeeded());
-        Assert.assertEquals(true, ar.result());
-        verify(pgClient).execute(anyString(), any(ArrayTuple.class), any(Handler.class));
-        async.complete();
-      });
+    messagingModuleDao.delete(new MessagingModuleFilter())
+    // then
+    .onComplete(context.asyncAssertSuccess(x -> {
+      verify(pgClient).execute(anyString());
+    }));
   }
 
   @Test
-  public void shouldReturnFutureWithFalseWhenEntityWithSpecifiedIdNotFound(TestContext context) {
-    // given
-    Async async = context.async();
-    RowSet<Row> updateResult = new LocalRowSet(0);
-
-    doAnswer(invocation -> {
-      Handler<AsyncResult<RowSet<Row>>> handler = invocation.getArgument(2);
-      handler.handle(Future.succeededFuture(updateResult));
-      return updateResult;
-    })
-      .when(pgClient).execute(anyString(), any(ArrayTuple.class), any(Handler.class));
-    // when
-    messagingModuleDao.delete(messagingModule.getId())
-      // then
-      .onComplete(ar -> {
-        Assert.assertTrue(ar.succeeded());
-        Assert.assertEquals(false, ar.result());
-        verify(pgClient).execute(anyString(), any(ArrayTuple.class), any(Handler.class));
-        async.complete();
-      });
+  public void shouldSucceedOnDeleteExisting(TestContext context) {
+    shouldSucceedOnDelete(context, 1);
   }
+
+  @Test
+  public void shouldSucceedOnDeleteNotFound(TestContext context) {
+    shouldSucceedOnDelete(context, 0);
+  }
+
 }


### PR DESCRIPTION
`Future<Boolean>` is used with true indicating success and false indicating failure. This results in two ways how a failure can be propagated: As a failing Future, or as a succeeding Future returning false. This results in bloated code and is error-prone.

The idiomatic way is to only use the built-in success/failure indicator of the Future and to use Void as the type: `Future<Void>`.

Approach:

Replace `Future<Boolean>` by `Future<Void>` and use the built-in error handling of Vert.x' Future: https://github.com/folio-org/raml-module-builder/blob/master/doc/futurisation.md#result-and-error-handling

MessagingModuleDao#delete(String id) is removed because it is not used.

The Boolean was set to "rowCount() == 1", however, the Boolean was not checked, a false Boolean was considered a successful delete.
Therefore the check is removed.