### PR TITLE
Extend diagnostics for failed pubsub user creation

### DIFF
--- a/mod-pubsub-server/src/main/java/org/folio/services/impl/SecurityManagerImpl.java
+++ b/mod-pubsub-server/src/main/java/org/folio/services/impl/SecurityManagerImpl.java
@@ -224,8 +224,9 @@ public class SecurityManagerImpl implements SecurityManager {
             systemUserConfig.getName());
           promise.complete(true);
         } else {
-          String errorMessage = format("Failed to add permissions for %s user. Received status code %s",
-            systemUserConfig.getName(), response.getCode());
+          String errorMessage = format("Failed to add permissions %s for %s user. Received status code %s: %s",
+            StringUtils.join(permissions, ","), systemUserConfig.getName(), response.getCode(),
+            response.getBody());
           LOGGER.error(errorMessage);
           promise.fail(errorMessage);
         }

--- a/mod-pubsub-server/src/test/java/org/folio/services/impl/SecurityManagerTest.java
+++ b/mod-pubsub-server/src/test/java/org/folio/services/impl/SecurityManagerTest.java
@@ -327,8 +327,8 @@ public class SecurityManagerTest {
     OkapiConnectionParams params = new OkapiConnectionParams(headers, vertx);
 
     securityManager.createPubSubUser(params).onComplete(context.asyncAssertFailure(x ->
-      assertEquals("Failed to add permissions for test-pubsub-username user. Received status code 403",
-        x.getMessage())
+      assertEquals("Failed to add permissions inventory.all for test-pubsub-username user."
+          + " Received status code 403: null", x.getMessage())
     ));
   }
 


### PR DESCRIPTION
At this point, when the error is reported, the message from mod-permissions is not logged.

Include that in the diagnostic.