### PR TITLE
Fix create/update pubsub user MODPUBSUB-221

### DIFF
--- a/README.md
+++ b/README.md
@@ -560,15 +560,11 @@ Keep in mind, that subscriber module should return response to the "mod-pubsub" 
 As a result, we can send an event from the publisher module to "mod-pubsub" and "mod-pubsub" will deliver it to the subscriber module.
 
 #### Permissions
-##### "mod-pubsub" permissions workflow:
-At first "mod-pubsub" checks whether the system user (default username is "pub-sub", see **System user credentials** for more details) user exists in the system. If user exists, then:
-- adds permissions from the file "pubsub-user-permissions.csv" to the system user.
 
- ##### Otherwise:
- If user does not exist in the system, then:
- - system user is created;
- - system user credentials are created;
- - permissions are assigned to the system user (new record with specific permissions added to the "user_permissions" table). 
+During tenant init (upgrade, enable), mod-pubsub checks whether the system user
+(default username is "pub-sub", see **System user credentials** for more details) user exists in the system.
+If the user does not exist, it is created and actived. In any case, permissions
+from the file `pubsub-user-permissions.csv` are assigned to the system user.
 
 ##### When system user is logged in, its token is used for delivering events to subscriber module.
 

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -202,7 +202,9 @@
             "users.item.post",
             "users.item.put",
             "login.item.post",
+            "perms.users.get",
             "perms.users.item.post",
+            "perms.users.item.put",
             "perms.users.assign.immutable"
           ]
         },

--- a/mod-pubsub-server/src/main/java/org/folio/rest/impl/ModTenantAPI.java
+++ b/mod-pubsub-server/src/main/java/org/folio/rest/impl/ModTenantAPI.java
@@ -29,8 +29,7 @@ public class ModTenantAPI extends TenantAPI {
         Vertx vertx = context.owner();
         LiquibaseUtil.initializeSchemaForTenant(vertx, tenantId);
         OkapiConnectionParams params = new OkapiConnectionParams(headers, vertx);
-        return securityManager.createPubSubUser(params)
-          .compose(ar -> securityManager.getJWTToken(params)).map(num);
+        return securityManager.createPubSubUser(params).map(num);
       });
   }
 }

--- a/mod-pubsub-server/src/main/java/org/folio/rest/util/OkapiConnectionParams.java
+++ b/mod-pubsub-server/src/main/java/org/folio/rest/util/OkapiConnectionParams.java
@@ -26,7 +26,7 @@ public final class OkapiConnectionParams {
   public OkapiConnectionParams(Map<String, String> okapiHeaders, Vertx vertx) {
     this.okapiUrl = okapiHeaders.getOrDefault(OKAPI_URL_HEADER, "localhost");
     this.tenantId = okapiHeaders.getOrDefault(OKAPI_TENANT_HEADER, "");
-    this.token = okapiHeaders.getOrDefault(OKAPI_TOKEN_HEADER, "dummy");
+    this.token = okapiHeaders.get(OKAPI_TOKEN_HEADER);
     this.headers = okapiHeaders;
     this.vertx = vertx;
   }

--- a/mod-pubsub-server/src/main/java/org/folio/services/impl/SecurityManagerImpl.java
+++ b/mod-pubsub-server/src/main/java/org/folio/services/impl/SecurityManagerImpl.java
@@ -14,7 +14,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.HttpStatus;
 import org.folio.config.user.SystemUserConfig;
-import org.folio.okapi.common.GenericCompositeFuture;
 import org.folio.representation.User;
 import org.folio.rest.util.OkapiConnectionParams;
 import org.folio.services.SecurityManager;
@@ -26,7 +25,6 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.UUID;
@@ -96,11 +94,11 @@ public class SecurityManagerImpl implements SecurityManager {
       .compose(user -> {
         if (user != null) {
           return updateUser(user, params)
-            .compose(updatedUser -> addPermissions(user.getId(), params));
+            .compose(updatedUser -> establishPermissionsUser(user.getId(), params));
         } else {
           return createUser(params)
             .compose(userId -> saveCredentials(userId, params))
-            .compose(userId -> assignPermissions(userId, params));
+            .compose(userId -> establishPermissionsUser(userId, params));
         }
       });
   }
@@ -196,47 +194,58 @@ public class SecurityManagerImpl implements SecurityManager {
       });
   }
 
-  private Future<Void> assignPermissions(String userId, OkapiConnectionParams params) {
-    JsonObject requestBody = new JsonObject()
-      .put("id", UUID.randomUUID().toString())
-      .put("userId", userId)
-      .put("permissions", new JsonArray(PERMISSIONS));
-    return doRequest(params, PERMISSIONS_URL, HttpMethod.POST, requestBody.encode())
-      .compose(response -> {
-        if (response.getCode() == HttpStatus.HTTP_CREATED.toInt()) {
-          LOGGER.info("Added permissions [{}] for {} user", StringUtils.join(PERMISSIONS, ","),
-            systemUserConfig.getName());
-          return Future.succeededFuture();
-        } else {
-          String errorMessage = format("Failed to add permissions %s for %s user. Received status code %s: %s",
-            StringUtils.join(PERMISSIONS, ","), systemUserConfig.getName(), response.getCode(),
-            response.getBody());
-          LOGGER.error(errorMessage);
-          return Future.failedFuture(errorMessage);
-        }
-      });
-  }
-
-  private Future<Void> addPermissions(String userId, OkapiConnectionParams params) {
-    List<Future<Void>> futures = new ArrayList<>();
-    String permUrl = PERMISSIONS_URL + "/" + userId + "/permissions?indexField=userId";
-    PERMISSIONS.forEach(permission -> {
-      JsonObject requestBody = new JsonObject()
-        .put("permissionName", permission);
-      futures.add(doRequest(params, permUrl, HttpMethod.POST, requestBody.encode())
-        .compose(response -> {
-          if (response.getCode() == HttpStatus.HTTP_OK.toInt()) {
-            LOGGER.info("Added permission {} for {} user", permission, systemUserConfig.getName());
-            return Future.succeededFuture();
-          } else {
-            String errorMessage = format("Failed to add permission %s for %s user. Received status code %s",
-              permission, systemUserConfig.getName(), response.getCode());
+  /**
+   * Create or Update permission user.
+   * @param userId user ID as known from mod-users
+   * @param params connection params.
+   * @return async result.
+   */
+  private Future<Void> establishPermissionsUser(String userId, OkapiConnectionParams params) {
+    // have to do a GET first as PUT does not allow indexField=userId.. If that was available, the
+    // GET would not be necessary.
+    return doRequest(params, PERMISSIONS_URL + "/" + userId + "?indexField=userId", HttpMethod.GET,
+      null).compose(res1 -> {
+      if (res1.getCode() == HttpStatus.HTTP_OK.toInt()) {
+        JsonObject requestBody = res1.getJson()
+          .put("permissions", new JsonArray(PERMISSIONS));
+        return doRequest(params, PERMISSIONS_URL + "/" + requestBody.getString("id"), HttpMethod.PUT,
+          requestBody.encode())
+          .compose(res2 -> {
+            if (res2.getCode() == HttpStatus.HTTP_OK.toInt()) {
+              LOGGER.info("Updated user {} with permissions [{}]", systemUserConfig.getName(),
+                StringUtils.join(PERMISSIONS, ","));
+              return Future.succeededFuture();
+            }
+            String errorMessage = format("Failed to update permissions %s for %s user. Received status code %s: %s",
+              StringUtils.join(PERMISSIONS, ","), systemUserConfig.getName(), res2.getCode(),
+              res2.getBody());
             LOGGER.error(errorMessage);
             return Future.failedFuture(errorMessage);
-          }
-        }));
+          });
+      } else if (res1.getCode() == HttpStatus.HTTP_NOT_FOUND.toInt()) {
+        JsonObject requestBody = new JsonObject()
+          .put("id", UUID.randomUUID().toString())
+          .put("userId", userId)
+          .put("permissions", new JsonArray(PERMISSIONS));
+        return doRequest(params, PERMISSIONS_URL, HttpMethod.POST, requestBody.encode())
+          .compose(res2 -> {
+            if (res2.getCode() == HttpStatus.HTTP_CREATED.toInt()) {
+              LOGGER.info("Created user {} with permissions [{}]", systemUserConfig.getName(),
+                StringUtils.join(PERMISSIONS, ","));
+              return Future.succeededFuture();
+            }
+            String errorMessage = format("Failed to add permissions %s for %s user. Received status code %s: %s",
+              StringUtils.join(PERMISSIONS, ","), systemUserConfig.getName(), res2.getCode(),
+              res2.getBody());
+            LOGGER.error(errorMessage);
+            return Future.failedFuture(errorMessage);
+          });
+      }
+      String errorMessage = format("Failed to get permissions for %s user. Received status code %s: %s",
+        systemUserConfig.getName(), res1.getCode(), res1.getBody());
+      LOGGER.error(errorMessage);
+      return Future.failedFuture(errorMessage);
     });
-    return GenericCompositeFuture.all(futures).mapEmpty();
   }
 
   static List<String> readPermissionsFromResource(String path) {

--- a/mod-pubsub-server/src/main/java/org/folio/services/impl/SecurityManagerImpl.java
+++ b/mod-pubsub-server/src/main/java/org/folio/services/impl/SecurityManagerImpl.java
@@ -206,6 +206,9 @@ public class SecurityManagerImpl implements SecurityManager {
     return doRequest(params, PERMISSIONS_URL + "/" + userId + "?indexField=userId", HttpMethod.GET,
       null).compose(res1 -> {
       if (res1.getCode() == HttpStatus.HTTP_OK.toInt()) {
+        if (res1.getJson().getJsonArray("permissions").equals(new JsonArray(PERMISSIONS))) {
+          return Future.succeededFuture();
+        }
         JsonObject requestBody = res1.getJson()
           .put("permissions", new JsonArray(PERMISSIONS));
         return doRequest(params, PERMISSIONS_URL + "/" + requestBody.getString("id"), HttpMethod.PUT,

--- a/mod-pubsub-server/src/test/java/org/folio/rest/impl/ModTenantApiTest.java
+++ b/mod-pubsub-server/src/test/java/org/folio/rest/impl/ModTenantApiTest.java
@@ -56,34 +56,6 @@ public class ModTenantApiTest extends AbstractRestTest {
   }
 
   @Test
-  public void shouldLoginWithEnvVarCredentials() {
-    final User user = existingUser();
-    final JsonObject userCollection = buildUserCollection(user);
-
-    wireMockRule.stubFor(get(GET_PUBSUB_USER_URL)
-      .willReturn(okJson(userCollection.toString())));
-    wireMockRule.stubFor(put(userByIdUrl(user.getId()))
-        .willReturn(aResponse().withStatus(204)));
-
-    String permId = UUID.randomUUID().toString();
-    JsonObject permUser = new JsonObject()
-      .put("id", permId)
-      .put("userId", user.getId())
-      .put("permissions", new JsonArray());
-
-    wireMockRule.stubFor(get("/perms/users/" + user.getId() + "?indexField=userId").willReturn(ok().withBody(permUser.encode())));
-    wireMockRule.stubFor(put("/perms/users/" + permId).willReturn(ok()));
-
-    getTenant();
-
-    verify(1, postRequestedFor(urlEqualTo(LOGIN_URL))
-      .withRequestBody(equalTo(new JsonObject()
-        .put("username", SYSTEM_USER_NAME)
-        .put("password", SYSTEM_USER_PASSWORD)
-        .encode())));
-  }
-
-  @Test
   public void shouldForwardUserUpdateError() {
     final String expectedErrorMessage = "User is broken";
 

--- a/mod-pubsub-server/src/test/java/org/folio/services/impl/SecurityManagerTest.java
+++ b/mod-pubsub-server/src/test/java/org/folio/services/impl/SecurityManagerTest.java
@@ -63,7 +63,6 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
-import scala.concurrent.impl.FutureConvertersImpl;
 
 @RunWith(VertxUnitRunner.class)
 public class SecurityManagerTest {

--- a/mod-pubsub-server/src/test/java/org/folio/services/impl/SecurityManagerTest.java
+++ b/mod-pubsub-server/src/test/java/org/folio/services/impl/SecurityManagerTest.java
@@ -5,6 +5,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.findAll;
 import static com.github.tomakehurst.wiremock.client.WireMock.forbidden;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.noContent;
+import static com.github.tomakehurst.wiremock.client.WireMock.notFound;
 import static com.github.tomakehurst.wiremock.client.WireMock.ok;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
@@ -30,6 +31,8 @@ import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.UUID;
 
+import com.github.tomakehurst.wiremock.matching.RegexPattern;
+import com.github.tomakehurst.wiremock.matching.UrlPattern;
 import org.folio.dao.MessagingModuleDao;
 import org.folio.dao.impl.MessagingModuleDaoImpl;
 import org.folio.config.user.SystemUserConfig;
@@ -60,6 +63,7 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
+import scala.concurrent.impl.FutureConvertersImpl;
 
 @RunWith(VertxUnitRunner.class)
 public class SecurityManagerTest {
@@ -143,7 +147,15 @@ public class SecurityManagerTest {
       .put("totalRecords", 1).encode();
 
     stubFor(get(USERS_URL_WITH_QUERY).willReturn(ok().withBody(userCollection)));
-    stubFor(post(permissionsByUserIdUrl(userId)).willReturn(ok()));
+
+    String permId = UUID.randomUUID().toString();
+    JsonObject permUser = new JsonObject()
+      .put("id", permId)
+      .put("userId", userId)
+      .put("permissions", new JsonArray());
+
+    stubFor(get(PERMISSIONS_URL + "/" + userId + "?indexField=userId").willReturn(ok().withBody(permUser.encode())));
+    stubFor(put(PERMISSIONS_URL + "/" + permId).willReturn(ok()));
 
     OkapiConnectionParams params = new OkapiConnectionParams(headers, vertx);
 
@@ -151,13 +163,16 @@ public class SecurityManagerTest {
 
     future.map(ar -> {
       List<LoggedRequest> requests = findAll(RequestPatternBuilder.allRequests());
-      assertEquals(2, requests.size());
+      assertEquals(3, requests.size());
 
       assertEquals(USERS_URL_WITH_QUERY, requests.get(0).getUrl());
       assertEquals("GET", requests.get(0).getMethod().getName());
 
-      assertEquals(permissionsByUserIdUrl(userId), requests.get(1).getUrl());
-      assertEquals("POST", requests.get(1).getMethod().getName());
+      assertEquals(PERMISSIONS_URL + "/" + userId + "?indexField=userId", requests.get(1).getUrl());
+      assertEquals("GET", requests.get(1).getMethod().getName());
+
+      assertEquals(PERMISSIONS_URL + "/" + permId, requests.get(2).getUrl());
+      assertEquals("PUT", requests.get(2).getMethod().getName());
 
       // Verify user create request has not sent
       verify(0, new RequestPatternBuilder(POST, urlEqualTo(USERS_URL)));
@@ -169,6 +184,7 @@ public class SecurityManagerTest {
   @Test
   public void shouldCreatePubSubUser(TestContext context) {
     String userId = UUID.randomUUID().toString();
+    System.out.println("Userid=" + userId);
     String userCollection = new JsonObject()
       .put("users", new JsonArray().add(existingUser(userId)))
       .put("totalRecords", 1).encode();
@@ -178,6 +194,7 @@ public class SecurityManagerTest {
     stubFor(post(USERS_URL).willReturn(created().withBody(userCollection)));
     stubFor(post(CREDENTIALS_URL).willReturn(created()));
     stubFor(post(PERMISSIONS_URL).willReturn(created()));
+    stubFor(get(new UrlPattern(new RegexPattern(PERMISSIONS_URL + "/.*"), true)).willReturn(notFound()));
 
     OkapiConnectionParams params = new OkapiConnectionParams(headers, vertx);
 
@@ -185,7 +202,7 @@ public class SecurityManagerTest {
 
     future.map(ar -> {
       List<LoggedRequest> requests = findAll(RequestPatternBuilder.allRequests());
-      assertEquals(4, requests.size());
+      assertEquals(5, requests.size());
 
       assertEquals(USERS_URL_WITH_QUERY, requests.get(0).getUrl());
       assertEquals("GET", requests.get(0).getMethod().getName());
@@ -197,8 +214,11 @@ public class SecurityManagerTest {
       assertEquals(CREDENTIALS_URL, requests.get(2).getUrl());
       assertEquals("POST", requests.get(2).getMethod().getName());
 
-      assertEquals(PERMISSIONS_URL, requests.get(3).getUrl());
-      assertEquals("POST", requests.get(3).getMethod().getName());
+      assertTrue( requests.get(4).getUrl().startsWith(PERMISSIONS_URL));
+      assertEquals("GET", requests.get(3).getMethod().getName());
+
+      assertTrue( requests.get(4).getUrl().startsWith(PERMISSIONS_URL));
+      assertEquals("POST", requests.get(4).getMethod().getName());
 
       return null;
     }).onComplete(context.asyncAssertSuccess());
@@ -243,14 +263,21 @@ public class SecurityManagerTest {
   @Test
   public void shouldUpdateExistingUser(TestContext context) {
     final String userId = UUID.randomUUID().toString();
-    final String permUrl = PERMISSIONS_URL + "/" + userId + "/permissions?indexField=userId";
     final String userCollection = new JsonObject()
       .put("users", new JsonArray().add(existingUser(userId)))
       .put("totalRecords", 1).encode();
 
     stubFor(get(USERS_URL_WITH_QUERY).willReturn(ok().withBody(userCollection)));
     stubFor(put(USERS_URL + "/" + userId).willReturn(noContent()));
-    stubFor(post(permUrl).willReturn(ok()));
+
+    String permId = UUID.randomUUID().toString();
+    JsonObject permUser = new JsonObject()
+      .put("id", permId)
+      .put("userId", userId)
+      .put("permissions", new JsonArray());
+
+    stubFor(get(PERMISSIONS_URL + "/" + userId + "?indexField=userId").willReturn(ok().withBody(permUser.encode())));
+    stubFor(put(PERMISSIONS_URL + "/" + permId).willReturn(ok()));
 
     OkapiConnectionParams params = new OkapiConnectionParams(headers, vertx);
 
@@ -258,7 +285,7 @@ public class SecurityManagerTest {
 
     future.map(ar -> {
       final List<LoggedRequest> requests = findAll(RequestPatternBuilder.allRequests());
-      assertEquals(3, requests.size());
+      assertEquals(4, requests.size());
 
       assertEquals(USERS_URL_WITH_QUERY, requests.get(0).getUrl());
       assertEquals("GET", requests.get(0).getMethod().getName());
@@ -267,44 +294,18 @@ public class SecurityManagerTest {
       assertEquals("PUT", requests.get(1).getMethod().getName());
       verifyUser(requests.get(1));
 
-      assertEquals(permUrl, requests.get(2).getUrl());
-      assertEquals("POST", requests.get(2).getMethod().getName());
+      assertEquals(PERMISSIONS_URL + "/" + userId + "?indexField=userId", requests.get(2).getUrl());
+      assertEquals("GET", requests.get(2).getMethod().getName());
+
+      assertEquals(PERMISSIONS_URL + "/" + permId, requests.get(3).getUrl());
+      assertEquals("PUT", requests.get(3).getMethod().getName());
 
       return null;
     }).onComplete(context.asyncAssertSuccess());
   }
 
   @Test
-  public void shouldNotUpdateExistingUserIfUpToDate(TestContext context) {
-    final String userId = UUID.randomUUID().toString();
-    final String userCollection = new JsonObject()
-      .put("users", new JsonArray().add(existingUpToDateUser(userId)))
-      .put("totalRecords", 1).encode();
-
-    stubFor(get(USERS_URL_WITH_QUERY).willReturn(ok().withBody(userCollection)));
-    stubFor(post(permissionsByUserIdUrl(userId)).willReturn(ok()));
-
-    OkapiConnectionParams params = new OkapiConnectionParams(headers, vertx);
-
-    Future<Void> future = securityManager.createPubSubUser(params);
-
-    future.map(ar -> {
-      final List<LoggedRequest> requests = findAll(RequestPatternBuilder.allRequests());
-      assertEquals(2, requests.size());
-
-      assertEquals(USERS_URL_WITH_QUERY, requests.get(0).getUrl());
-      assertEquals("GET", requests.get(0).getMethod().getName());
-
-      assertEquals(permissionsByUserIdUrl(userId), requests.get(1).getUrl());
-      assertEquals("POST", requests.get(1).getMethod().getName());
-
-      return null;
-    }).onComplete(context.asyncAssertSuccess());
-  }
-
-
-  @Test
-  public void shouldFailPubSubUser(TestContext context) {
+  public void permissionsFailGet(TestContext context) {
     String userId = UUID.randomUUID().toString();
     String userCollection = new JsonObject()
       .put("users", new JsonArray().add(existingUser(userId)))
@@ -314,14 +315,62 @@ public class SecurityManagerTest {
       .willReturn(ok().withBody(emptyUsersResponse().encode())));
     stubFor(post(USERS_URL).willReturn(created().withBody(userCollection)));
     stubFor(post(CREDENTIALS_URL).willReturn(created()));
-    stubFor(post(PERMISSIONS_URL).willReturn(forbidden()));
+    stubFor(get(new UrlPattern(new RegexPattern(PERMISSIONS_URL + "/.*"), true)).willReturn(forbidden().withBody("x")));
 
     OkapiConnectionParams params = new OkapiConnectionParams(headers, vertx);
 
-    securityManager.createPubSubUser(params).onComplete(context.asyncAssertFailure(x ->
+    securityManager.createPubSubUser(params).onComplete(context.asyncAssertFailure(res -> {
+       assertEquals("Failed to get permissions for test-pubsub-username user. Received status code 403: x", res.getMessage());
+    }));
+  }
+
+  @Test
+  public void permissionsFailPost(TestContext context) {
+    String userId = UUID.randomUUID().toString();
+    String userCollection = new JsonObject()
+      .put("users", new JsonArray().add(existingUser(userId)))
+      .put("totalRecords", 1).encode();
+
+    stubFor(get(USERS_URL_WITH_QUERY)
+      .willReturn(ok().withBody(emptyUsersResponse().encode())));
+    stubFor(post(USERS_URL).willReturn(created().withBody(userCollection)));
+    stubFor(post(CREDENTIALS_URL).willReturn(created()));
+    stubFor(get(new UrlPattern(new RegexPattern(PERMISSIONS_URL + "/.*"), true)).willReturn(notFound()));
+    stubFor(post(PERMISSIONS_URL).willReturn(forbidden().withBody("x")));
+
+    OkapiConnectionParams params = new OkapiConnectionParams(headers, vertx);
+
+    securityManager.createPubSubUser(params).onComplete(context.asyncAssertFailure(res -> {
       assertEquals("Failed to add permissions inventory.all for test-pubsub-username user."
-          + " Received status code 403: null", x.getMessage())
-    ));
+        + " Received status code 403: x", res.getMessage());
+    }));
+  }
+
+  @Test
+  public void permissionsFailPut(TestContext context) {
+    final String userId = UUID.randomUUID().toString();
+    final String userCollection = new JsonObject()
+      .put("users", new JsonArray().add(existingUser(userId)))
+      .put("totalRecords", 1).encode();
+
+    stubFor(get(USERS_URL_WITH_QUERY).willReturn(ok().withBody(userCollection)));
+    stubFor(put(USERS_URL + "/" + userId).willReturn(noContent()));
+
+    String permId = UUID.randomUUID().toString();
+    JsonObject permUser = new JsonObject()
+      .put("id", permId)
+      .put("userId", userId)
+      .put("permissions", new JsonArray());
+
+    stubFor(get(PERMISSIONS_URL + "/" + userId + "?indexField=userId").willReturn(ok().withBody(permUser.encode())));
+    stubFor(put(PERMISSIONS_URL + "/" + permId).willReturn(forbidden().withBody("x")));
+
+    OkapiConnectionParams params = new OkapiConnectionParams(headers, vertx);
+
+    securityManager.createPubSubUser(params).onComplete(context.asyncAssertFailure(res -> {
+      assertEquals("Failed to update permissions inventory.all for test-pubsub-username user."
+        + " Received status code 403: x", res.getMessage());
+    }));
   }
 
   @Test(expected = NoSuchElementException.class)
@@ -361,10 +410,6 @@ public class SecurityManagerTest {
       .put("addresses", new JsonArray());
 
     return existingUser(id).put("personal", personal);
-  }
-
-  private String permissionsByUserIdUrl(String userId) {
-    return PERMISSIONS_URL + "/" + userId + "/permissions?indexField=userId";
   }
 
   private JsonObject emptyUsersResponse() {


### PR DESCRIPTION
The new strategy only involves handling 404, 201, 200 codes -
rest is considered an error. A permission user is either created
or updated with permissions necessary. If mod-users user is created
and mod-pubsub crashes before mod-permissions, then mod-permissions
user is created as it should be.

Do not supply an invalid X-Okapi-token "dummy" anymore.

Do not get token during tenant init. It's not needed for anything during init.