### PR TITLE
OkapiConnectionParams takes vertx parameter

### DIFF
--- a/mod-pubsub-client/src/main/java/org/folio/rest/client/WebClientProvider.java
+++ b/mod-pubsub-client/src/main/java/org/folio/rest/client/WebClientProvider.java
@@ -12,7 +12,7 @@ public class WebClientProvider {
   private WebClientProvider() {
   }
 
-  public static WebClient getWebClient(Vertx vertx) {
+  public static synchronized WebClient getWebClient(Vertx vertx) {
     return webClients.computeIfAbsent(vertx, WebClient::create);
   }
 }

--- a/mod-pubsub-client/src/main/java/org/folio/rest/util/OkapiConnectionParams.java
+++ b/mod-pubsub-client/src/main/java/org/folio/rest/util/OkapiConnectionParams.java
@@ -13,11 +13,8 @@ public final class OkapiConnectionParams {
   private String tenantId;
   private String token;
   private Map<String, String> headers;
-  private Vertx vertx;
+  private final Vertx vertx;
   private int timeout = 2000;
-
-  public OkapiConnectionParams() {
-  }
 
   public OkapiConnectionParams(Vertx vertx) {
     this.vertx = vertx;
@@ -65,10 +62,6 @@ public final class OkapiConnectionParams {
 
   public Vertx getVertx() {
     return vertx;
-  }
-
-  public void setVertx(Vertx vertx) {
-    this.vertx = vertx;
   }
 
   public int getTimeout() {

--- a/mod-pubsub-server/src/main/java/org/folio/rest/impl/PubSubImpl.java
+++ b/mod-pubsub-server/src/main/java/org/folio/rest/impl/PubSubImpl.java
@@ -6,7 +6,6 @@ import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
-import io.vertx.core.logging.LoggerFactory;
 
 import org.apache.commons.lang.time.DateFormatUtils;
 import org.apache.commons.lang.time.DateUtils;


### PR DESCRIPTION
Do not allow OkapiConnectionParams to be constructed without supplying a vertx handle.
A one line change to mod-circulation-storage and mod-circulation.
The other modules do not require code changes and tests pass on them.