### PR TITLE
MODPUBSUB-228: kafka-clients 3.1.0 fixing timing attack (CVE-2021-38153)

### DIFF
--- a/mod-pubsub-client/pom.xml
+++ b/mod-pubsub-client/pom.xml
@@ -80,12 +80,10 @@
     <dependency>
       <groupId>org.apache.kafka</groupId>
       <artifactId>kafka-clients</artifactId>
-      <version>2.5.0</version>
     </dependency>
     <dependency>
       <groupId>net.mguenther.kafka</groupId>
       <artifactId>kafka-junit</artifactId>
-      <version>2.5.0</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>

--- a/mod-pubsub-server/pom.xml
+++ b/mod-pubsub-server/pom.xml
@@ -106,7 +106,6 @@
     <dependency>
       <groupId>org.apache.kafka</groupId>
       <artifactId>kafka-clients</artifactId>
-      <version>2.5.0</version>
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>
@@ -116,7 +115,6 @@
     <dependency>
       <groupId>net.mguenther.kafka</groupId>
       <artifactId>kafka-junit</artifactId>
-      <version>2.5.0</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>

--- a/mod-pubsub-server/src/test/java/org/folio/rest/impl/AbstractRestTest.java
+++ b/mod-pubsub-server/src/test/java/org/folio/rest/impl/AbstractRestTest.java
@@ -22,11 +22,9 @@ import org.folio.rest.tools.utils.NetworkUtils;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.ClassRule;
-
 import static java.lang.String.format;
 import static net.mguenther.kafka.junit.EmbeddedKafkaCluster.provisionWith;
-import static net.mguenther.kafka.junit.EmbeddedKafkaClusterConfig.useDefaults;
+import static net.mguenther.kafka.junit.EmbeddedKafkaClusterConfig.defaultClusterConfig;
 import static org.folio.rest.RestVerticle.OKAPI_HEADER_TENANT;
 
 public abstract class AbstractRestTest {
@@ -62,12 +60,12 @@ public abstract class AbstractRestTest {
   static RequestSpecification spec;
   private static String useExternalDatabase;
   protected static Vertx vertx;
-
-  @ClassRule
-  public static EmbeddedKafkaCluster cluster = provisionWith(useDefaults());
+  public static EmbeddedKafkaCluster cluster;
 
   @BeforeClass
   public static void setUpClass(final TestContext context) throws Exception {
+    cluster = provisionWith(defaultClusterConfig());
+    cluster.start();
     vertx = Vertx.vertx();
     runDatabase();
     String[] hostAndPort = cluster.getBrokerList().split(":");
@@ -77,6 +75,12 @@ public abstract class AbstractRestTest {
     System.setProperty(SYSTEM_USER_NAME_ENV, SYSTEM_USER_NAME);
     System.setProperty(SYSTEM_USER_PASSWORD_ENV, SYSTEM_USER_PASSWORD);
     deployVerticle(context);
+  }
+
+  @AfterClass
+  public static void tearDownClass() {
+    cluster.stop();
+    cluster = null;
   }
 
   private static void runDatabase() throws Exception {

--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,7 @@
 
   <dependencyManagement>
     <dependencies>
+
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-bom</artifactId>
@@ -40,6 +41,7 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-stack-depchain</artifactId>
@@ -47,6 +49,19 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+
+      <dependency>
+        <groupId>org.apache.kafka</groupId>
+        <artifactId>kafka-clients</artifactId>
+        <version>3.1.0</version>
+      </dependency>
+
+      <dependency>
+        <groupId>net.mguenther.kafka</groupId>
+        <artifactId>kafka-junit</artifactId>
+        <version>3.1.0</version>
+      </dependency>
+
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
org.apache.kafka:kafka-clients:2.5.0 has a brute force timing attack vulnerability: https://nvd.nist.gov/vuln/detail/CVE-2021-38153

Versions >= 2.8.1 are fixed.

Solution: Bump the version from 2.5.0 to latest 3.1.0.

This requires to remove @ClassRule from EmbeddedKafkaCluster
variable and start and stop it manually because it no longer
extends ExternalResource since 2.7.0.