### PR TITLE
MODPUBSUB-229: Remove jaxrs-code-generator (CVE-2019-10172)

### DIFF
--- a/mod-pubsub-server/pom.xml
+++ b/mod-pubsub-server/pom.xml
@@ -71,17 +71,6 @@
       <version>${jackson.jaxb.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.raml.jaxrs</groupId>
-      <artifactId>jaxrs-code-generator</artifactId>
-      <version>3.0.2</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.scala-lang</groupId>
-          <artifactId>scala-library</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
       <groupId>org.folio</groupId>
       <artifactId>folio-liquibase-util</artifactId>
       <version>1.3.0</version>
@@ -159,6 +148,11 @@
       <groupId>org.folio</groupId>
       <artifactId>postgres-testing</artifactId>
       <version>${raml-module-builder.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/mod-pubsub-server/src/main/java/org/folio/rest/util/ExceptionHelper.java
+++ b/mod-pubsub-server/src/main/java/org/folio/rest/util/ExceptionHelper.java
@@ -1,7 +1,6 @@
 package org.folio.rest.util;
 
 import io.vertx.core.Promise;
-import org.apache.http.HttpStatus;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.rest.tools.utils.ValidationHelper;
@@ -10,6 +9,7 @@ import javax.ws.rs.BadRequestException;
 import javax.ws.rs.NotFoundException;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
 
 public final class ExceptionHelper {
 
@@ -21,13 +21,13 @@ public final class ExceptionHelper {
   public static Response mapExceptionToResponse(Throwable throwable) {
     LOGGER.error(throwable.getMessage());
     if (throwable instanceof BadRequestException) {
-      return Response.status(HttpStatus.SC_BAD_REQUEST)
+      return Response.status(Status.BAD_REQUEST)
         .type(MediaType.TEXT_PLAIN)
         .entity(throwable.getMessage())
         .build();
     }
     if (throwable instanceof NotFoundException) {
-      return Response.status(HttpStatus.SC_NOT_FOUND)
+      return Response.status(Status.NOT_FOUND)
         .type(MediaType.TEXT_PLAIN)
         .entity(throwable.getMessage())
         .build();
@@ -36,13 +36,13 @@ public final class ExceptionHelper {
     ValidationHelper.handleError(throwable, validationPromise);
     if (validationPromise.future().isComplete()) {
       Response response = validationPromise.future().result();
-      if (response.getStatus() == HttpStatus.SC_INTERNAL_SERVER_ERROR) {
+      if (response.getStatus() == Status.INTERNAL_SERVER_ERROR.getStatusCode()) {
         LOGGER.error(throwable.getMessage(), throwable);
       }
       return response;
     }
     LOGGER.error(throwable.getMessage(), throwable);
-    return Response.status(HttpStatus.SC_INTERNAL_SERVER_ERROR)
+    return Response.status(Status.INTERNAL_SERVER_ERROR)
       .type(MediaType.TEXT_PLAIN)
       .entity(Response.Status.INTERNAL_SERVER_ERROR.getReasonPhrase())
       .build();

--- a/mod-pubsub-server/src/test/java/org/folio/services/impl/SecurityManagerTest.java
+++ b/mod-pubsub-server/src/test/java/org/folio/services/impl/SecurityManagerTest.java
@@ -26,6 +26,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.when;
 
+import java.time.Instant;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -38,8 +39,6 @@ import org.folio.config.user.SystemUserConfig;
 import org.folio.representation.User;
 import org.folio.rest.util.OkapiConnectionParams;
 import org.folio.services.cache.Cache;
-import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -429,16 +428,16 @@ public class SecurityManagerTest {
 
   private JsonObject existingUser(String id) {
     final JsonObject metadata = new JsonObject()
-      .put("createdDate", DateTime.now(DateTimeZone.UTC).toString())
-      .put("updatedDate", DateTime.now(DateTimeZone.UTC).toString());
+      .put("createdDate", Instant.now())
+      .put("updatedDate", Instant.now());
 
     return new JsonObject()
       .put("id", id)
       .put("username", SYSTEM_USER_NAME)
       .put("active", "true")
       .put("proxyFor", new JsonArray())
-      .put("createdDate", DateTime.now(DateTimeZone.UTC).toString())
-      .put("updatedDate", DateTime.now(DateTimeZone.UTC).toString())
+      .put("createdDate", Instant.now())
+      .put("updatedDate", Instant.now())
       .put("metadata", metadata);
   }
 

--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,13 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+      <dependency>
+        <groupId>org.mockito</groupId>
+        <artifactId>mockito-bom</artifactId>
+        <version>4.3.1</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
Remove org.raml.jaxrs:jaxrs-code-generator:3.0.2 runtime dependency.

jaxrs-code-generator is not needed and has many vulnerable dependencies:

* org.mozilla:rhino@1.7R4 https://security.snyk.io/vuln/SNYK-JAVA-ORGMOZILLA-1314295
* com.google.code.gson:gson@2.5 https://app.snyk.io/vuln/SNYK-JAVA-COMGOOGLECODEGSON-1730327
* org.codehaus.jackson:jackson-mapper-asl@1.9.1 https://nvd.nist.gov/vuln/detail/CVE-2019-10172
* commons-io:commons-io@2.4 https://nvd.nist.gov/vuln/detail/CVE-2021-29425
* org.apache.httpcomponents:httpclient@4.0.1 https://nvd.nist.gov/vuln/detail/CVE-2014-3577, https://nvd.nist.gov/vuln/detail/CVE-2012-6153, https://nvd.nist.gov/vuln/detail/CVE-2011-1498
* org.yaml:snakeyaml@1.15 https://nvd.nist.gov/vuln/detail/CVE-2017-18640
* com.google.guava:guava@19.0 https://nvd.nist.gov/vuln/detail/CVE-2020-8908, https://nvd.nist.gov/vuln/detail/CVE-2018-10237
* commons-codec:commons-codec@1.9 https://app.snyk.io/vuln/SNYK-JAVA-COMMONSCODEC-561518

Only 3 dependencies of jaxrs-code-generator have been used: mockito-core, joda time,
and org.apache.http.HttpStatus. We can add mockito-core as a direct dependency,
use java.time.Instant instead of joda time, and replace org.apache.http.HttpStatus
by javax.ws.rs.core.Response.Status.