### PR TITLE
FOLIO-3231 Use new api-lint and api-doc CI facilities

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,9 +2,12 @@ buildMvn {
   publishModDescriptor = 'yes'
   publishAPI = 'yes'
   mvnDeploy = 'yes'
-  runLintRamlCop = 'yes'
   doKubeDeploy = true
   buildNode = 'jenkins-agent-java11'
+
+  doApiLint = true
+  apiTypes = 'RAML'
+  apiDirectories = 'ramls'
 
   doDocker = {
     buildJavaDocker {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,11 +1,11 @@
 buildMvn {
   publishModDescriptor = 'yes'
-  publishAPI = 'yes'
   mvnDeploy = 'yes'
   doKubeDeploy = true
   buildNode = 'jenkins-agent-java11'
 
   doApiLint = true
+  doApiDoc = true
   apiTypes = 'RAML'
   apiDirectories = 'ramls'
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # mod-pubsub
 
-Copyright (C) 2019 The Open Library Foundation
+Copyright (C) 2019-2022 The Open Library Foundation
 
 This software is distributed under the terms of the Apache License, Version 2.0.
 See the file "[LICENSE](LICENSE)" for more information.

--- a/ramls/pubSub.raml
+++ b/ramls/pubSub.raml
@@ -74,7 +74,7 @@ resourceTypes:
             200:
               body:
                 application/json:
-                  schema: messagingModuleCollection
+                  type: messagingModuleCollection
         delete:
           description: Remove publisher declaration for certain event type
           queryParameters:
@@ -94,7 +94,7 @@ resourceTypes:
             200:
               body:
                 application/json:
-                  schema: messagingModuleCollection
+                  type: messagingModuleCollection
         delete:
           description:  API to remove Subscriber declaration for certain event type
           queryParameters:
@@ -113,13 +113,13 @@ resourceTypes:
           description: Declare a publisher for a set of event types
           body:
             application/json:
-              schema: publisherDescriptor
+              type: publisherDescriptor
           responses:
             201:
             400:
               body:
                 application/json:
-                  schema: errors
+                  type: errors
             500:
               description: "Internal server error"
               body:
@@ -131,13 +131,13 @@ resourceTypes:
         post:
           body:
             application/json:
-              schema: subscriberDescriptor
+              type: subscriberDescriptor
           responses:
             201:
             400:
               body:
                 application/json:
-                  schema: errors
+                  type: errors
             500:
               description: "Internal server error"
               body:
@@ -177,7 +177,7 @@ resourceTypes:
         200:
           body:
             application/json:
-              schema: auditMessageCollection
+              type: auditMessageCollection
         400:
           description: "Bad request"
           body:
@@ -197,7 +197,7 @@ resourceTypes:
         200:
           body:
             application/json:
-              schema: auditMessagePayload
+              type: auditMessagePayload
         404:
           description: "Not found"
           body:
@@ -214,13 +214,13 @@ resourceTypes:
     post:
       body:
         application/json:
-          schema: event
+          type: event
       responses:
         204:
         400:
           body:
             application/json:
-              schema: errors
+              type: errors
         500:
           description: "Internal server error"
           body:


### PR DESCRIPTION
The doApiLint facility replaces runLintRamlCop
https://dev.folio.org/guides/api-lint/

The doApiDoc facility replaces publishAPI
https://dev.folio.org/guides/api-doc/

The https://dev.folio.org/reference/api/#mod-pubsub section of API documentation will be automatically reconfigured:
https://dev.folio.org/reference/api/#explain-gather-config
