### PR TITLE
MODPUBSUB-231: Update dependencies fixing CVE-2022-0839, CVE-2020-36518

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,8 +12,7 @@ buildMvn {
   doDocker = {
     buildJavaDocker {
       publishMaster = 'yes'
-      healthChk = 'yes'
-      healthChkCmd = 'curl -sS --fail -o /dev/null  http://localhost:8081/admin/health || exit 1'
+      // healthChk is in PubSubIT.java because starting the module requires a running PostgreSQL
     }
   }
 }

--- a/mod-pubsub-client/pom.xml
+++ b/mod-pubsub-client/pom.xml
@@ -39,7 +39,7 @@
     <dependency>
       <groupId>org.liquibase</groupId>
       <artifactId>liquibase-core</artifactId>
-      <version>3.4.1</version>
+      <version>4.9.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/mod-pubsub-server/pom.xml
+++ b/mod-pubsub-server/pom.xml
@@ -359,6 +359,21 @@
           </execution>
         </executions>
       </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <version>3.0.0-M6</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>integration-test</goal>
+              <goal>verify</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-release-plugin</artifactId>

--- a/mod-pubsub-server/pom.xml
+++ b/mod-pubsub-server/pom.xml
@@ -68,12 +68,11 @@
     <dependency>
       <groupId>com.fasterxml.jackson.module</groupId>
       <artifactId>jackson-module-jaxb-annotations</artifactId>
-      <version>${jackson.jaxb.version}</version>
     </dependency>
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>folio-liquibase-util</artifactId>
-      <version>1.3.0</version>
+      <version>1.4.1</version>
       <type>jar</type>
       <exclusions>
         <exclusion>

--- a/mod-pubsub-server/pom.xml
+++ b/mod-pubsub-server/pom.xml
@@ -98,7 +98,6 @@
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-web-client</artifactId>
-      <version>${vertx.version}</version>
     </dependency>
     <dependency>
       <groupId>net.mguenther.kafka</groupId>
@@ -150,6 +149,16 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>postgresql</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-slf4j-impl</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/mod-pubsub-server/src/test/java/org/folio/rest/impl/PubSubIT.java
+++ b/mod-pubsub-server/src/test/java/org/folio/rest/impl/PubSubIT.java
@@ -1,0 +1,113 @@
+package org.folio.rest.impl;
+
+import static io.restassured.RestAssured.given;
+import static io.restassured.RestAssured.when;
+import static org.hamcrest.Matchers.is;
+
+import io.restassured.RestAssured;
+import io.restassured.builder.RequestSpecBuilder;
+import io.restassured.http.ContentType;
+import io.vertx.core.json.JsonObject;
+import java.nio.file.Path;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.Network;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
+import org.testcontainers.images.builder.ImageFromDockerfile;
+
+/**
+ * Test that the shaded fat uber jar works and that the Dockerfile works.
+ */
+public class PubSubIT {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(PubSubIT.class);
+
+  private static final Network network = Network.newNetwork();
+
+  @ClassRule
+  public static final GenericContainer<?> module =
+    new GenericContainer<>(
+      new ImageFromDockerfile("mod-pubsub").withFileFromPath("..", Path.of("..")))
+    .withNetwork(network)
+    .withExposedPorts(8081)
+    .withEnv("DB_HOST", "postgres")
+    .withEnv("DB_PORT", "5432")
+    .withEnv("DB_USERNAME", "username")
+    .withEnv("DB_PASSWORD", "password")
+    .withEnv("DB_DATABASE", "postgres");
+
+  @ClassRule
+  public static final PostgreSQLContainer<?> postgres =
+    new PostgreSQLContainer<>("postgres:12-alpine")
+    .withNetwork(network)
+    .withNetworkAliases("postgres")
+    .withExposedPorts(5432)
+    .withUsername("username")
+    .withPassword("password")
+    .withDatabaseName("postgres");
+
+  @BeforeClass
+  public static void beforeClass() {
+    RestAssured.reset();
+    RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
+    RestAssured.baseURI = "http://" + module.getHost() + ":" + module.getFirstMappedPort();
+    RestAssured.requestSpecification = new RequestSpecBuilder()
+        .addHeader("X-Okapi-Tenant", "testtenant")
+        .setContentType(ContentType.JSON)
+        .build();
+
+    module.followOutput(new Slf4jLogConsumer(LOGGER).withSeparateOutputStreams());
+  }
+
+  @Test
+  public void health() {
+    when().
+      get("/admin/health").
+    then().
+      statusCode(200).
+      body(is("\"OK\""));
+  }
+
+  private void postTenant(JsonObject body) {
+    String location =
+        given().
+          body(body.encodePrettily()).
+        when().
+          post("/_/tenant").
+        then().
+          statusCode(201).
+        extract().
+          header("Location");
+
+    when().
+      get(location + "?wait=30000").
+    then().
+      statusCode(200).
+      body("complete", is(true));
+  }
+
+  @Test
+  public void installAndUpgrade() {
+    postTenant(new JsonObject().put("module_to", "999999.0.0"));
+    // migrate from 0.0.0 to test that migration is idempotent
+    postTenant(new JsonObject().put("module_to", "999999.0.0").put("module_from", "0.0.0"));
+
+    // smoke test
+    given().
+      body(new JsonObject()
+          .put("eventType", "FOLIO_RELEASE_PARTY_ANNOUNCEMENT")
+          .put("eventTTL", "1")
+          .encodePrettily()).
+    when().
+      post("/pubsub/event-types").
+    then().
+      statusCode(201).
+      body("eventType", is("FOLIO_RELEASE_PARTY_ANNOUNCEMENT"));
+  }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -19,13 +19,12 @@
   </modules>
 
   <properties>
-    <raml-module-builder.version>33.2.4</raml-module-builder.version>
-    <vertx.version>4.2.4</vertx.version>
+    <raml-module-builder.version>33.2.8</raml-module-builder.version>
+    <vertx.version>4.2.6</vertx.version>
     <lombok.version>1.18.16</lombok.version>
     <wiremock.version>2.27.2</wiremock.version>
     <junit.version>4.13.1</junit.version>
     <rest-assured.version>4.3.1</rest-assured.version>
-    <jackson.jaxb.version>2.10.0</jackson.jaxb.version>
     <main.basedir>${project.basedir}</main.basedir>
     <ramlfiles_path>${basedir}/ramls</ramlfiles_path>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,14 @@
       </dependency>
 
       <dependency>
+        <groupId>org.testcontainers</groupId>
+        <artifactId>testcontainers-bom</artifactId>
+        <version>1.17.1</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+
+      <dependency>
         <groupId>org.apache.kafka</groupId>
         <artifactId>kafka-clients</artifactId>
         <version>3.1.0</version>


### PR DESCRIPTION
Update folio-liquibase-util from 1.3.0 to 1.4.1. This updates liquibase from 4.7.1 to 4.9.0 fixing https://nvd.nist.gov/vuln/detail/CVE-2022-0839

Update liquibase from 3.4.1 to 4.9.0 fixing https://nvd.nist.gov/vuln/detail/CVE-2022-0839

Update RMB from 33.2.4 to 33.2.8. This updates jackson-databind from 2.13.1 to 2.13.2.1 fixing https://nvd.nist.gov/vuln/detail/CVE-2020-36518

Update Vert.x from 4.2.4 to 4.2.6.