### PR TITLE
MODPUBSUB-232: jackson-databind 2.13.2.1 (CVE-2020-36518)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,8 +19,8 @@
   </modules>
 
   <properties>
-    <raml-module-builder.version>33.2.8</raml-module-builder.version>
-    <vertx.version>4.2.6</vertx.version>
+    <raml-module-builder.version>33.2.9</raml-module-builder.version>
+    <vertx.version>4.2.7</vertx.version>
     <lombok.version>1.18.16</lombok.version>
     <wiremock.version>2.27.2</wiremock.version>
     <junit.version>4.13.1</junit.version>


### PR DESCRIPTION
Update from jackson-databind 2.13.1 to 2.13.2.1 fixing StackOverflow exception
and denial of service via a large depth of nested objects:
https://nvd.nist.gov/vuln/detail/CVE-2020-36518

Approach:
Bump RMB from 33.2.8 to 33.2.9 and Vert.x from 4.2.6 to 4.2.7.
vertx-dependencies contain jackson with the fix.