### PR TITLE
MODPUBSUB-233: folio-di-support 1.5.1, spring-beans 5.3.19

### DIFF
--- a/mod-pubsub-client/pom.xml
+++ b/mod-pubsub-client/pom.xml
@@ -74,7 +74,6 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>folio-di-support</artifactId>
-      <version>1.2.0</version>
       <type>jar</type>
     </dependency>
     <dependency>

--- a/mod-pubsub-server/pom.xml
+++ b/mod-pubsub-server/pom.xml
@@ -57,7 +57,6 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>folio-di-support</artifactId>
-      <version>1.4.1</version>
       <type>jar</type>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,12 @@
       </dependency>
 
       <dependency>
+        <groupId>org.folio</groupId>
+        <artifactId>folio-di-support</artifactId>
+        <version>1.5.1</version>
+      </dependency>
+
+      <dependency>
         <groupId>org.apache.kafka</groupId>
         <artifactId>kafka-clients</artifactId>
         <version>3.1.0</version>


### PR DESCRIPTION
Upgrade folio-di-support from folio-di-support:1.2.0 (mod-pubsub-client) and folio-di-support:1.4.1 (mod-pubsub-server) to folio-di-support:1.5.1 (each).

This indirectly upgrades spring-beans from 5.2.8 to 5.3.19 fixing Remote Code Execution: https://nvd.nist.gov/vuln/detail/CVE-2022-22965