### PR TITLE
MODPUBSUB-234: Release 2.5.1

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,15 @@
+## 2022-05-04 v2.5.1
+* [MODPUBSUB-228](https://issues.folio.org/browse/MODPUBSUB-228) Update kafka-clients fixing timing attack (CVE-2021-38153)
+* [MODPUBSUB-229](MODPUBSUB-229) Remove jaxrs-code-generator (CVE-2019-10172)
+* [MODPUBSUB-214](MODPUBSUB-214) Replace Future<Boolean> by Future<Void> in EventDescriptorDao
+* [MODPUBSUB-215](MODPUBSUB-215) Replace Future<Boolean> by Future<Void> in ConsumerService
+* [MODPUBSUB-217](MODPUBSUB-217) Replace Future<Boolean> by Future<Void> in KafkaTopicService
+* [FOLIO-1021](FOLIO-1021) Update copyright year
+* [FOLIO-3231](FOLIO-3231) Use new api-lint. Use new api-doc. Replace deprecated 'schema' keyword, use 'type' for RAML 1.0.
+* [MODPUBSUB-231](MODPUBSUB-231) Update dependencies fixing CVE-2022-0839, CVE-2020-36518
+* [MODPUBSUB-232](MODPUBSUB-232) jackson-databind 2.13.2.1 (CVE-2020-36518)
+* [MODPUBSUB-233](MODPUBSUB-233) folio-di-support 1.5.1, spring-beans 5.3.19 (CVE-2022-22965)
+
 ## 2022-02-22 v2.5.0
 * [MODPUBSUB-209](https://issues.folio.org/browse/MODPUBSUB-209) Add pubsub-user permission to post events
 * [MODPUBSUB-210](https://issues.folio.org/browse/MODPUBSUB-210) Fix incorrect status for tenant init

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,14 +1,14 @@
 ## 2022-05-04 v2.5.1
 * [MODPUBSUB-228](https://issues.folio.org/browse/MODPUBSUB-228) Update kafka-clients fixing timing attack (CVE-2021-38153)
-* [MODPUBSUB-229](MODPUBSUB-229) Remove jaxrs-code-generator (CVE-2019-10172)
-* [MODPUBSUB-214](MODPUBSUB-214) Replace Future<Boolean> by Future<Void> in EventDescriptorDao
-* [MODPUBSUB-215](MODPUBSUB-215) Replace Future<Boolean> by Future<Void> in ConsumerService
-* [MODPUBSUB-217](MODPUBSUB-217) Replace Future<Boolean> by Future<Void> in KafkaTopicService
-* [FOLIO-1021](FOLIO-1021) Update copyright year
-* [FOLIO-3231](FOLIO-3231) Use new api-lint. Use new api-doc. Replace deprecated 'schema' keyword, use 'type' for RAML 1.0.
-* [MODPUBSUB-231](MODPUBSUB-231) Update dependencies fixing CVE-2022-0839, CVE-2020-36518
-* [MODPUBSUB-232](MODPUBSUB-232) jackson-databind 2.13.2.1 (CVE-2020-36518)
-* [MODPUBSUB-233](MODPUBSUB-233) folio-di-support 1.5.1, spring-beans 5.3.19 (CVE-2022-22965)
+* [MODPUBSUB-229](https://issues.folio.org/browse/MODPUBSUB-229) Remove jaxrs-code-generator (CVE-2019-10172)
+* [MODPUBSUB-214](https://issues.folio.org/browse/MODPUBSUB-214) Replace Future<Boolean> by Future<Void> in EventDescriptorDao
+* [MODPUBSUB-215](https://issues.folio.org/browse/MODPUBSUB-215) Replace Future<Boolean> by Future<Void> in ConsumerService
+* [MODPUBSUB-217](https://issues.folio.org/browse/MODPUBSUB-217) Replace Future<Boolean> by Future<Void> in KafkaTopicService
+* [FOLIO-1021](https://issues.folio.org/browse/FOLIO-1021) Update copyright year
+* [FOLIO-3231](https://issues.folio.org/browse/FOLIO-3231) Use new api-lint. Use new api-doc. Replace deprecated 'schema' keyword, use 'type' for RAML 1.0.
+* [MODPUBSUB-231](https://issues.folio.org/browse/MODPUBSUB-231) Update dependencies fixing CVE-2022-0839, CVE-2020-36518
+* [MODPUBSUB-232](https://issues.folio.org/browse/MODPUBSUB-232) jackson-databind 2.13.2.1 (CVE-2020-36518)
+* [MODPUBSUB-233](https://issues.folio.org/browse/MODPUBSUB-233) folio-di-support 1.5.1, spring-beans 5.3.19 (CVE-2022-22965)
 
 ## 2022-02-22 v2.5.0
 * [MODPUBSUB-209](https://issues.folio.org/browse/MODPUBSUB-209) Add pubsub-user permission to post events

--- a/mod-pubsub-client/pom.xml
+++ b/mod-pubsub-client/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <artifactId>mod-pubsub</artifactId>
     <groupId>org.folio</groupId>
-    <version>2.5.1-SNAPSHOT</version>
+    <version>2.5.1</version>
   </parent>
 
   <properties>

--- a/mod-pubsub-client/pom.xml
+++ b/mod-pubsub-client/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <artifactId>mod-pubsub</artifactId>
     <groupId>org.folio</groupId>
-    <version>2.5.1</version>
+    <version>2.5.2-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/mod-pubsub-server/pom.xml
+++ b/mod-pubsub-server/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>mod-pubsub</artifactId>
     <groupId>org.folio</groupId>
-    <version>2.5.1</version>
+    <version>2.5.2-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/mod-pubsub-server/pom.xml
+++ b/mod-pubsub-server/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>mod-pubsub</artifactId>
     <groupId>org.folio</groupId>
-    <version>2.5.1-SNAPSHOT</version>
+    <version>2.5.1</version>
   </parent>
 
   <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>mod-pubsub</artifactId>
-  <version>2.5.1</version>
+  <version>2.5.2-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <licenses>
@@ -218,7 +218,7 @@
     <url>https://github.com/folio-org/mod-pubsub</url>
     <connection>scm:git:git://github.com/folio-org/mod-pubsub</connection>
     <developerConnection>scm:git:git@github.com:folio-org/mod-pubsub.git</developerConnection>
-    <tag>v2.5.1</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>mod-pubsub</artifactId>
-  <version>2.5.1-SNAPSHOT</version>
+  <version>2.5.1</version>
   <packaging>pom</packaging>
 
   <licenses>
@@ -218,7 +218,7 @@
     <url>https://github.com/folio-org/mod-pubsub</url>
     <connection>scm:git:git://github.com/folio-org/mod-pubsub</connection>
     <developerConnection>scm:git:git@github.com:folio-org/mod-pubsub.git</developerConnection>
-    <tag>HEAD</tag>
+    <tag>v2.5.1</tag>
   </scm>
 
   <repositories>


### PR DESCRIPTION
## Purpose
Release 2.5.1 with bug fixes, most of them fix security vulnerabilities.

Most notable fix:
Spring4Shell ([FOLIO-3466](https://issues.folio.org/browse/FOLIO-3466) = [MODPUBSUB-233](https://issues.folio.org/browse/MODPUBSUB-233)): Upgrade spring-beans from 5.2.8 to 5.3.19 fixing Remote Code Execution: https://nvd.nist.gov/vuln/detail/CVE-2022-22965