### PR TITLE
MODPUBSUB-242: Upgrade lombok to 1.18.24 for Java 17

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
   <properties>
     <raml-module-builder.version>34.0.0</raml-module-builder.version>
     <vertx.version>4.2.7</vertx.version>
-    <lombok.version>1.18.16</lombok.version>
+    <lombok.version>1.18.24</lombok.version>
     <wiremock.version>2.27.2</wiremock.version>
     <junit.version>4.13.1</junit.version>
     <rest-assured.version>4.3.1</rest-assured.version>


### PR DESCRIPTION
How to reproduce:

Use JDK of Java 17.

```
mvn clean install
```

Expected result: Build succeeds

Actual result: Build fails with this error:

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.8.1:compile (default-compile) on project mod-pubsub-client: Fatal error compiling: java.lang.IllegalAccessError: class lombok.javac.apt.LombokProcessor (in unnamed module @0x5843f0e9) cannot access class com.sun.tools.javac.processing.JavacProcessingEnvironment (in module jdk.compiler) because module jdk.compiler does not export com.sun.tools.javac.processing to unnamed module @0x5843f0e9 -> [Help 1]
```

Solution: Upgrade lombok from 1.18.16 to 1.18.24

## Purpose
Build should be possible when using Java 17 JDK.

## Approach
Upgrade ombok from 1.18.16 to 1.18.24