### PR TITLE
MODPUBSUB-246: Upgrade dependencies fixing vulnerabilities

### DIFF
--- a/mod-pubsub-client/pom.xml
+++ b/mod-pubsub-client/pom.xml
@@ -33,13 +33,12 @@
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-unit</artifactId>
-      <version>${vertx.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.liquibase</groupId>
       <artifactId>liquibase-core</artifactId>
-      <version>4.9.0</version>
+      <version>4.15.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -102,7 +101,6 @@
     <dependency>
       <groupId>org.scala-lang</groupId>
       <artifactId>scala-library</artifactId>
-      <version>2.13.1</version>
     </dependency>
     <dependency>
       <groupId>com.github.tomakehurst</groupId>
@@ -119,7 +117,7 @@
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-model</artifactId>
-      <version>3.3.9</version>
+      <version>3.8.6</version>
     </dependency>
   </dependencies>
 

--- a/mod-pubsub-server/pom.xml
+++ b/mod-pubsub-server/pom.xml
@@ -62,7 +62,7 @@
     <dependency>
       <groupId>org.postgresql</groupId>
       <artifactId>postgresql</artifactId>
-      <version>42.3.3</version>
+      <version>42.5.0</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.module</groupId>
@@ -71,7 +71,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>folio-liquibase-util</artifactId>
-      <version>1.4.1</version>
+      <version>1.5.1</version>
       <type>jar</type>
       <exclusions>
         <exclusion>
@@ -120,7 +120,6 @@
     <dependency>
       <groupId>org.scala-lang</groupId>
       <artifactId>scala-library</artifactId>
-      <version>2.13.1</version>
     </dependency>
     <dependency>
       <groupId>com.github.tomakehurst</groupId>
@@ -137,7 +136,7 @@
     <dependency>
       <groupId>com.github.ben-manes.caffeine</groupId>
       <artifactId>caffeine</artifactId>
-      <version>2.8.5</version>
+      <version>3.1.1</version>
     </dependency>
     <dependency>
       <groupId>org.folio</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -19,12 +19,12 @@
   </modules>
 
   <properties>
-    <raml-module-builder.version>34.0.0</raml-module-builder.version>
-    <vertx.version>4.2.7</vertx.version>
+    <raml-module-builder.version>34.0.2</raml-module-builder.version>
+    <vertx.version>4.3.3</vertx.version>
     <lombok.version>1.18.24</lombok.version>
     <wiremock.version>2.27.2</wiremock.version>
-    <junit.version>4.13.1</junit.version>
-    <rest-assured.version>4.3.1</rest-assured.version>
+    <junit.version>4.13.2</junit.version>
+    <rest-assured.version>5.1.1</rest-assured.version>
     <main.basedir>${project.basedir}</main.basedir>
     <ramlfiles_path>${basedir}/ramls</ramlfiles_path>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -36,7 +36,7 @@
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-bom</artifactId>
-        <version>2.17.1</version>
+        <version>2.18.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -52,15 +52,21 @@
       <dependency>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-bom</artifactId>
-        <version>4.3.1</version>
+        <version>4.7.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
 
       <dependency>
+        <groupId>org.scala-lang</groupId>
+        <artifactId>scala-library</artifactId>
+        <version>2.13.8</version>
+      </dependency>
+
+      <dependency>
         <groupId>org.testcontainers</groupId>
         <artifactId>testcontainers-bom</artifactId>
-        <version>1.17.1</version>
+        <version>1.17.3</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -68,19 +74,19 @@
       <dependency>
         <groupId>org.folio</groupId>
         <artifactId>folio-di-support</artifactId>
-        <version>1.5.1</version>
+        <version>1.6.0</version>
       </dependency>
 
       <dependency>
         <groupId>org.apache.kafka</groupId>
         <artifactId>kafka-clients</artifactId>
-        <version>3.1.0</version>
+        <version>3.2.1</version>
       </dependency>
 
       <dependency>
         <groupId>net.mguenther.kafka</groupId>
         <artifactId>kafka-junit</artifactId>
-        <version>3.1.0</version>
+        <version>3.2.0</version>
       </dependency>
 
     </dependencies>


### PR DESCRIPTION
Upgrade folio-di-support from 1.5.1 to 1.6.0, this upgrades spring-beans from 5.3.19 to 5.3.20 fixing Denial of Service (DoS): https://nvd.nist.gov/vuln/detail/CVE-2022-22970

Upgrade maven-model from 3.3.9 to 3.8.6, this upgrades plexus-utils from 3.0.22 to 3.3.1 fixing these vulnerabilities: https://app.snyk.io/vuln/SNYK-JAVA-ORGCODEHAUSPLEXUS-31521 , https://app.snyk.io/vuln/SNYK-JAVA-ORGCODEHAUSPLEXUS-461102

Upgrade postgresql from 42.3.3 to 42.5.0 fixing SQL Injection: https://nvd.nist.gov/vuln/detail/CVE-2022-31197

Upgrade RMB from 34.0.0 to 34.0.2.
Upgrade Vert.x from 4.2.7 to 4.3.3.
Upgrade folio-liquibase-util from 1.4.1 to 1.5.1.
Upgrade caffeine from 2.8.5 to 3.1.1.
Upgrade log4j from 2.17.1 to 2.18.0.
Upgrade scala-library from 2.13.1 to 2.13.8.
Upgrade kafka-clients from 3.1.0 to 3.2.1.

Test dependencies:
Upgrade JUnit from 4.13.1 to 4.13.2.
Upgrade Rest Assured from 4.3.1 to 5.1.1.
Upgrade liquibase-core from 4.9.0 to 4.15.0.
Upgrade mockito from 4.3.1 to 4.7.0.
Upgrade testcontainers from 1.17.1 to 1.17.3.
Upgrade kafka-junit from 3.1.0 to 3.2.0.