### PR TITLE
MODPUBSUB-251: kafka-clients 3.2.3 fixing out-of-memory vulnerability

### DIFF
--- a/mod-pubsub-client/pom.xml
+++ b/mod-pubsub-client/pom.xml
@@ -76,33 +76,6 @@
       <type>jar</type>
     </dependency>
     <dependency>
-      <groupId>org.apache.kafka</groupId>
-      <artifactId>kafka-clients</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>net.mguenther.kafka</groupId>
-      <artifactId>kafka-junit</artifactId>
-      <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>org.slf4j</groupId>
-          <artifactId>slf4j-log4j12</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>log4j</groupId>
-          <artifactId>log4j</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>net.sf.jopt-simple</groupId>
-          <artifactId>jopt-simple</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>org.scala-lang</groupId>
-      <artifactId>scala-library</artifactId>
-    </dependency>
-    <dependency>
       <groupId>com.github.tomakehurst</groupId>
       <artifactId>wiremock</artifactId>
       <version>2.27.2</version>

--- a/mod-pubsub-server/pom.xml
+++ b/mod-pubsub-server/pom.xml
@@ -118,10 +118,6 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>org.scala-lang</groupId>
-      <artifactId>scala-library</artifactId>
-    </dependency>
-    <dependency>
       <groupId>com.github.tomakehurst</groupId>
       <artifactId>wiremock</artifactId>
       <version>2.27.2</version>

--- a/pom.xml
+++ b/pom.xml
@@ -58,12 +58,6 @@
       </dependency>
 
       <dependency>
-        <groupId>org.scala-lang</groupId>
-        <artifactId>scala-library</artifactId>
-        <version>2.13.8</version>
-      </dependency>
-
-      <dependency>
         <groupId>org.testcontainers</groupId>
         <artifactId>testcontainers-bom</artifactId>
         <version>1.17.3</version>
@@ -80,7 +74,7 @@
       <dependency>
         <groupId>org.apache.kafka</groupId>
         <artifactId>kafka-clients</artifactId>
-        <version>3.2.1</version>
+        <version>3.2.3</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
Upgrade kafka-clients from 3.2.1 to 3.2.3. This fixes an out-of-memory vulnerability: https://nvd.nist.gov/vuln/detail/CVE-2022-34917

Remove unused dependencies from pom.xml: scala-library, kafka-clients (from mod-pubsub-client), kafka-junit (from mod-pubsub-client).