### PR TITLE
MODPUBSUB-248 Invalid token ConsumerServiceImpl while delivering LOG_RECORD event

### DIFF
--- a/mod-pubsub-server/src/main/java/org/folio/rest/util/OkapiConnectionParams.java
+++ b/mod-pubsub-server/src/main/java/org/folio/rest/util/OkapiConnectionParams.java
@@ -9,6 +9,7 @@ public final class OkapiConnectionParams {
   public static final String OKAPI_URL_HEADER = "x-okapi-url";
   public static final String OKAPI_TENANT_HEADER = "x-okapi-tenant";
   public static final String OKAPI_TOKEN_HEADER = "x-okapi-token";
+  public static final String USER_ID = "X-Okapi-User-Id";
   private String okapiUrl;
   private String tenantId;
   private String token;

--- a/mod-pubsub-server/src/main/java/org/folio/services/impl/KafkaConsumerServiceImpl.java
+++ b/mod-pubsub-server/src/main/java/org/folio/services/impl/KafkaConsumerServiceImpl.java
@@ -42,6 +42,7 @@ import static java.lang.String.format;
 import static org.apache.commons.collections4.CollectionUtils.isEmpty;
 import static org.folio.rest.RestVerticle.MODULE_SPECIFIC_ARGS;
 import static org.folio.rest.jaxrs.model.MessagingModule.ModuleRole.SUBSCRIBER;
+import static org.folio.rest.util.OkapiConnectionParams.USER_ID;
 import static org.folio.rest.util.RestUtil.doRequest;
 import static org.folio.services.util.AuditUtil.constructJsonAuditMessage;
 import static org.folio.services.util.MessagingModulesUtil.filter;
@@ -162,6 +163,7 @@ public class KafkaConsumerServiceImpl implements ConsumerService {
           if (statusCode >= 400 && statusCode < 500) {
             LOGGER.info("Invalidating token for tenant {}", tenantId);
             securityManager.invalidateToken(tenantId);
+            params.getHeaders().remove(USER_ID);
           }
           retryDelivery(event, subscriber, params, retry);
         } else {

--- a/mod-pubsub-server/src/test/java/org/folio/services/impl/ConsumerServiceUnitTest.java
+++ b/mod-pubsub-server/src/test/java/org/folio/services/impl/ConsumerServiceUnitTest.java
@@ -1,9 +1,5 @@
 package org.folio.services.impl;
 
-import static org.folio.rest.util.OkapiConnectionParams.OKAPI_TENANT_HEADER;
-import static org.folio.rest.util.OkapiConnectionParams.OKAPI_TOKEN_HEADER;
-import static org.folio.rest.util.OkapiConnectionParams.OKAPI_URL_HEADER;
-import static org.folio.rest.util.OkapiConnectionParams.USER_ID;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -64,6 +60,11 @@ public class ConsumerServiceUnitTest {
   private static final String TOKEN = "token";
   private static final String CALLBACK_ADDRESS = "/source-storage/records";
   private static final String EVENT_TYPE = "record_created";
+
+  private static final String OKAPI_URL_HEADER = "x-okapi-url";
+  private static final String OKAPI_TENANT_HEADER = "x-okapi-tenant";
+  private static final String OKAPI_TOKEN_HEADER = "x-okapi-token";
+  private static final String USER_ID = "X-Okapi-User-Id";
 
   private Vertx vertx = Vertx.vertx();
   @Mock
@@ -341,9 +342,9 @@ public class ConsumerServiceUnitTest {
   private OkapiConnectionParams buildOkapiConnectionParams() {
     OkapiConnectionParams params = new OkapiConnectionParams(vertx);
     params.setHeaders(headers);
-    params.setOkapiUrl(headers.getOrDefault("x-okapi-url", "localhost"));
-    params.setTenantId(headers.getOrDefault("x-okapi-tenant", TENANT));
-    params.setToken(headers.getOrDefault("x-okapi-token", TOKEN));
+    params.setOkapiUrl(headers.getOrDefault(OKAPI_URL_HEADER, "localhost"));
+    params.setTenantId(headers.getOrDefault(OKAPI_TENANT_HEADER, TENANT));
+    params.setToken(headers.getOrDefault(OKAPI_TOKEN_HEADER, TOKEN));
     params.setTimeout(2000);
 
     return params;

--- a/mod-pubsub-server/src/test/java/org/folio/services/impl/ConsumerServiceUnitTest.java
+++ b/mod-pubsub-server/src/test/java/org/folio/services/impl/ConsumerServiceUnitTest.java
@@ -3,7 +3,9 @@ package org.folio.services.impl;
 import static org.folio.rest.util.OkapiConnectionParams.OKAPI_TENANT_HEADER;
 import static org.folio.rest.util.OkapiConnectionParams.OKAPI_TOKEN_HEADER;
 import static org.folio.rest.util.OkapiConnectionParams.OKAPI_URL_HEADER;
+import static org.folio.rest.util.OkapiConnectionParams.USER_ID;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -284,6 +286,7 @@ public class ConsumerServiceUnitTest {
   private void checkThatInvalidateTokenWasInvoked(TestContext context) {
     Async async = context.async();
     var event = buildEvent();
+    headers.put(USER_ID, UUID.randomUUID().toString());
     var params = buildOkapiConnectionParams();
     when(cache.getMessagingModules()).thenReturn(Future.succeededFuture(buildMessagingModules()));
 
@@ -291,6 +294,7 @@ public class ConsumerServiceUnitTest {
       assertTrue(ar.succeeded());
       verify(securityManager, atLeast(1)).invalidateToken(TENANT);
       verify(cache, atLeast(1)).invalidateToken(TENANT);
+      assertNull(headers.get(USER_ID));
       async.complete();
     });
   }


### PR DESCRIPTION
## Purpose
A record in logs that the user with the barcode checked out the item

## Approach
- remove invalid userId from headers for token invalidation

Resolves: [MODPUBSUB-248](https://issues.folio.org/browse/MODPUBSUB-248)