### PR TITLE
MODPUBSUB-254: snakeyaml 1.33, Vert.x 4.3.4, RMB 35.0.1

### DIFF
--- a/mod-pubsub-client/pom.xml
+++ b/mod-pubsub-client/pom.xml
@@ -36,12 +36,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.liquibase</groupId>
-      <artifactId>liquibase-core</artifactId>
-      <version>4.15.0</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.folio</groupId>
       <artifactId>domain-models-api-interfaces</artifactId>
       <version>${raml-module-builder.version}</version>
@@ -50,12 +44,6 @@
       <groupId>org.folio</groupId>
       <artifactId>mod-pubsub-server</artifactId>
       <version>${project.parent.version}</version>
-      <exclusions>
-        <exclusion>
-            <groupId>org.liquibase</groupId>
-            <artifactId>liquibase-core</artifactId>
-        </exclusion>
-      </exclusions>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/mod-pubsub-server/pom.xml
+++ b/mod-pubsub-server/pom.xml
@@ -71,11 +71,11 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>folio-liquibase-util</artifactId>
-      <version>1.5.1</version>
+      <version>1.5.2</version>
       <type>jar</type>
       <exclusions>
         <exclusion>
-          <groupId> ch.qos.logback</groupId>
+          <groupId>ch.qos.logback</groupId>
           <artifactId>logback-classic</artifactId>
         </exclusion>
       </exclusions>

--- a/pom.xml
+++ b/pom.xml
@@ -19,8 +19,8 @@
   </modules>
 
   <properties>
-    <raml-module-builder.version>35.0.0</raml-module-builder.version>
-    <vertx.version>4.3.3</vertx.version>
+    <raml-module-builder.version>35.0.1</raml-module-builder.version>
+    <vertx.version>4.3.4</vertx.version>
     <lombok.version>1.18.24</lombok.version>
     <wiremock.version>2.27.2</wiremock.version>
     <junit.version>4.13.2</junit.version>


### PR DESCRIPTION
Upgrade folio-liquibase-util from 1.5.1 to 1.5.2, this indirectly upgrades snakeyaml from 1.27 to 1.33 fixing Denial of Service (DoS) and Stack-based Buffer Overflow vulnerabilities: https://nvd.nist.gov/vuln/detail/CVE-2022-25857
https://nvd.nist.gov/vuln/detail/CVE-2022-38749
https://nvd.nist.gov/vuln/detail/CVE-2022-38750
https://nvd.nist.gov/vuln/detail/CVE-2022-38751
https://nvd.nist.gov/vuln/detail/CVE-2022-38752

Upgrade Vert.x from 4.3.3 to 4.3.4.

Upgrade RMB from 35.0.0 to 35.0.1.

Fix ConsumerServiceUnitTest:
* Replace deprecated MockitoAnnotations.initMocks by MockitoAnnotations.openMocks
* Replace context.async() (that misses context.verify) by (concise and more idiomatic) context.asyncAssertSuccess
* Replace times(messagingModuleList.size()) by atLeast(messagingModuleList.size()) to prevent sporadic failures caused by a race condition