### PR TITLE
MODPUBSUB-245 use testcontainers kafka instead of kafka-junit in order not to depend on local env

### DIFF
--- a/mod-pubsub-server/pom.xml
+++ b/mod-pubsub-server/pom.xml
@@ -99,25 +99,6 @@
       <artifactId>vertx-web-client</artifactId>
     </dependency>
     <dependency>
-      <groupId>net.mguenther.kafka</groupId>
-      <artifactId>kafka-junit</artifactId>
-      <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>org.slf4j</groupId>
-          <artifactId>slf4j-log4j12</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>log4j</groupId>
-          <artifactId>log4j</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>net.sf.jopt-simple</groupId>
-          <artifactId>jopt-simple</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
       <groupId>com.github.tomakehurst</groupId>
       <artifactId>wiremock</artifactId>
       <version>2.27.2</version>
@@ -148,6 +129,11 @@
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>postgresql</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>kafka</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -77,12 +77,6 @@
         <version>3.2.3</version>
       </dependency>
 
-      <dependency>
-        <groupId>net.mguenther.kafka</groupId>
-        <artifactId>kafka-junit</artifactId>
-        <version>3.2.0</version>
-      </dependency>
-
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
## Purpose
Resolves [MODPUBSUB-245](https://issues.folio.org/browse/MODPUBSUB-245) - tests fail if kafka service is already running

## Approach
use testcontainers kafka instead of kafka-junit in order not to depend on local env