### PR TITLE
MODPUBSUB-270 enable tenant collection topics

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,17 +130,13 @@ The partition count controls how many logs the topic will be sharded into.
  ```   
 If these values are not set then topics will be created with 1 partition and 1 replica.
 
-There is one more parameter which will determine if tenant collection topics are used. Tenant collection topics are
-topics created for a tenants for a particular event type. The traditional behaviour is the create a topic for each
-tenant given a event type.
+The optional `KAFKA_PRODUCER_TENANT_COLLECTION` must match the regex `[A-Z][A-Z0-9]{0,30}`, for details see [Kafka Tenant Collection Topics RFC](https://github.com/folio-org/rfcs/blob/master/text/0002-kafka-tenant-collection-topics.md).
 ```
       {
         "name": "KAFKA_PRODUCER_TENANT_COLLECTION",
         "value": "ALL"
       }
 ```
-The value of the parameter above should match the regex [A-Z][A-Z0-9]{0,30}. If this parameter is not set, tenant
-collection topics will not be used.
 
 ****In case a single Kafka installation is shared between multiple environments, make sure to set a customized prefix for kafka topics, specifying the environment in which pubsub is deployed****
 This variable is used as a prefix to avoid any confusion with Kafka topics and consumer groups and is ****REQUIRED**** to prevent the situation when events are exchanged between pubsub instances belonging to different environments.

--- a/README.md
+++ b/README.md
@@ -128,7 +128,19 @@ The partition count controls how many logs the topic will be sharded into.
         "value": "1"
       }
  ```   
-If these values are not set then topics will be created with 1 partition and 1 replica. 
+If these values are not set then topics will be created with 1 partition and 1 replica.
+
+There is one more parameter which will determine if tenant collection topics are used. Tenant collection topics are
+topics created for a tenants for a particular event type. The traditional behaviour is the create a topic for each
+tenant given a event type.
+```
+      {
+        "name": "KAFKA_PRODUCER_TENANT_COLLECTION",
+        "value": "ALL"
+      }
+```
+The value of the parameter above should match the regex [A-Z][A-Z0-9]{0,30}. If this parameter is not set, tenant
+collection topics will not be used.
 
 ****In case a single Kafka installation is shared between multiple environments, make sure to set a customized prefix for kafka topics, specifying the environment in which pubsub is deployed****
 This variable is used as a prefix to avoid any confusion with Kafka topics and consumer groups and is ****REQUIRED**** to prevent the situation when events are exchanged between pubsub instances belonging to different environments.

--- a/mod-pubsub-client/pom.xml
+++ b/mod-pubsub-client/pom.xml
@@ -16,6 +16,7 @@
     <sonar.exclusions>**/PubsubClient.java</sonar.exclusions>
     <sonar.exclusions>**/PomReader.java</sonar.exclusions>
     <sonar.exclusions>**/WebClientProvider.java</sonar.exclusions>
+    <sonar.exclusions>**/ApplicationConfig.java</sonar.exclusions>
   </properties>
 
   <dependencies>

--- a/mod-pubsub-client/pom.xml
+++ b/mod-pubsub-client/pom.xml
@@ -16,7 +16,6 @@
     <sonar.exclusions>**/PubsubClient.java</sonar.exclusions>
     <sonar.exclusions>**/PomReader.java</sonar.exclusions>
     <sonar.exclusions>**/WebClientProvider.java</sonar.exclusions>
-    <sonar.exclusions>**/ApplicationConfig.java</sonar.exclusions>
   </properties>
 
   <dependencies>

--- a/mod-pubsub-server/pom.xml
+++ b/mod-pubsub-server/pom.xml
@@ -141,6 +141,12 @@
       <artifactId>log4j-slf4j-impl</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <version>4.2.0</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/mod-pubsub-server/pom.xml
+++ b/mod-pubsub-server/pom.xml
@@ -12,7 +12,7 @@
     <basedir>${project.parent.basedir}</basedir>
     <ramlfiles_path>${project.parent.basedir}/ramls</ramlfiles_path>
     <sonar.exclusions>**/OkapiConnectionParams.java</sonar.exclusions>
-    <sonar.exclusions>**/ApplicationConfig.java</sonar.exclusions>
+    <!--sonar.exclusions>**/ApplicationConfig.java</sonar.exclusions-->
   </properties>
 
   <dependencies>

--- a/mod-pubsub-server/pom.xml
+++ b/mod-pubsub-server/pom.xml
@@ -12,7 +12,6 @@
     <basedir>${project.parent.basedir}</basedir>
     <ramlfiles_path>${project.parent.basedir}/ramls</ramlfiles_path>
     <sonar.exclusions>**/OkapiConnectionParams.java</sonar.exclusions>
-    <!--sonar.exclusions>**/ApplicationConfig.java</sonar.exclusions-->
   </properties>
 
   <dependencies>

--- a/mod-pubsub-server/pom.xml
+++ b/mod-pubsub-server/pom.xml
@@ -12,6 +12,7 @@
     <basedir>${project.parent.basedir}</basedir>
     <ramlfiles_path>${project.parent.basedir}/ramls</ramlfiles_path>
     <sonar.exclusions>**/OkapiConnectionParams.java</sonar.exclusions>
+    <sonar.exclusions>**/ApplicationConfig.java</sonar.exclusions>
   </properties>
 
   <dependencies>

--- a/mod-pubsub-server/src/main/java/org/folio/config/ApplicationConfig.java
+++ b/mod-pubsub-server/src/main/java/org/folio/config/ApplicationConfig.java
@@ -1,7 +1,10 @@
 package org.folio.config;
 
-import io.vertx.core.Vertx;
-import io.vertx.kafka.admin.KafkaAdminClient;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.annotation.PreDestroy;
+
 import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.folio.kafka.KafkaConfig;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -9,9 +12,8 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 
-import javax.annotation.PreDestroy;
-import java.util.HashMap;
-import java.util.Map;
+import io.vertx.core.Vertx;
+import io.vertx.kafka.admin.KafkaAdminClient;
 
 @Configuration
 @ComponentScan(basePackages = {

--- a/mod-pubsub-server/src/main/java/org/folio/config/ApplicationConfig.java
+++ b/mod-pubsub-server/src/main/java/org/folio/config/ApplicationConfig.java
@@ -9,6 +9,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 
+import javax.annotation.PreDestroy;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -21,11 +22,18 @@ import java.util.Map;
   "org.folio.config.user"})
 public class ApplicationConfig {
 
+  private KafkaAdminClient adminClient;
   @Bean
   public KafkaAdminClient kafkaAdminClient(@Autowired Vertx vertx, @Autowired KafkaConfig config) {
     Map<String, String> configs = new HashMap<>();
     configs.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, config.getKafkaUrl());
-    return KafkaAdminClient.create(vertx, configs);
+    adminClient = KafkaAdminClient.create(vertx, configs);
+    return adminClient;
+  }
+
+  @PreDestroy
+  public void closeAdminClient(){
+    adminClient.close(1_000);
   }
 
 }

--- a/mod-pubsub-server/src/main/java/org/folio/config/ApplicationConfig.java
+++ b/mod-pubsub-server/src/main/java/org/folio/config/ApplicationConfig.java
@@ -32,7 +32,7 @@ public class ApplicationConfig {
   }
 
   @PreDestroy
-  public void closeAdminClient(){
+  public void closeAdminClient() {
     adminClient.close(1_000);
   }
 

--- a/mod-pubsub-server/src/main/java/org/folio/config/ApplicationConfig.java
+++ b/mod-pubsub-server/src/main/java/org/folio/config/ApplicationConfig.java
@@ -20,7 +20,7 @@ import java.util.Map;
   "org.folio.rest",
   "org.folio.kafka",
   "org.folio.config.user"})
-public class ApplicationConfig { //NOSONAR
+public class ApplicationConfig {
 
   private KafkaAdminClient adminClient;
   @Bean

--- a/mod-pubsub-server/src/main/java/org/folio/config/ApplicationConfig.java
+++ b/mod-pubsub-server/src/main/java/org/folio/config/ApplicationConfig.java
@@ -20,7 +20,7 @@ import java.util.Map;
   "org.folio.rest",
   "org.folio.kafka",
   "org.folio.config.user"})
-public class ApplicationConfig {
+public class ApplicationConfig { //NOSONAR
 
   private KafkaAdminClient adminClient;
   @Bean

--- a/mod-pubsub-server/src/main/java/org/folio/kafka/PubSubConfig.java
+++ b/mod-pubsub-server/src/main/java/org/folio/kafka/PubSubConfig.java
@@ -1,15 +1,25 @@
 package org.folio.kafka;
 
+import org.apache.commons.lang3.StringUtils;
 import org.folio.rest.tools.utils.ModuleName;
 
 import static java.lang.String.join;
 
 public class PubSubConfig {
   private static final String PUB_SUB_PREFIX = "pub-sub";
+  private static final String TENANT_COLLECTION_TOPICS_ENV_VAR_NAME = "KAFKA_PRODUCER_TENANT_COLLECTION";
+  private static final String TENANT_COLLECTION_MATCH_REGEX = "[A-Z][A-Z0-9]{0,30}";
+  private static String TENANT_COLLECTION_TOPIC_QUALIFIER;
+  private static boolean TENANT_COLLECTION_TOPICS_ENABLED;
   private String tenant;
   private String eventType;
   private String groupId;
   private String topicName;
+
+  static {
+    TENANT_COLLECTION_TOPIC_QUALIFIER = System.getenv(TENANT_COLLECTION_TOPICS_ENV_VAR_NAME);
+    setTenantCollectionTopicsQualifier(TENANT_COLLECTION_TOPIC_QUALIFIER);
+  }
 
   public PubSubConfig(String env, String tenant, String eventType) {
     this.tenant = tenant;
@@ -17,8 +27,22 @@ public class PubSubConfig {
     /* moduleNameWithVersion variable need for unique topic and group names for different pub-sub versions.
     It was encapsulated here, in constructor, for better creating/subscribing/sending events.*/
     String moduleNameWithVersion = ModuleName.getModuleName().replace("_", "-") + "-" + ModuleName.getModuleVersion();
-    this.groupId = join(".", env, PUB_SUB_PREFIX, tenant, eventType, moduleNameWithVersion);
-    this.topicName = join(".", env, PUB_SUB_PREFIX, tenant, eventType, moduleNameWithVersion);
+    String topicQualifier = TENANT_COLLECTION_TOPICS_ENABLED ? TENANT_COLLECTION_TOPIC_QUALIFIER : tenant;
+    this.groupId = join(".", env, PUB_SUB_PREFIX, topicQualifier, eventType, moduleNameWithVersion);
+    this.topicName = join(".", env, PUB_SUB_PREFIX, topicQualifier, eventType, moduleNameWithVersion);
+  }
+
+  protected static void setTenantCollectionTopicsQualifier(String value) {
+    TENANT_COLLECTION_TOPIC_QUALIFIER = value;
+    TENANT_COLLECTION_TOPICS_ENABLED = !StringUtils.isEmpty(TENANT_COLLECTION_TOPIC_QUALIFIER);
+
+    if(TENANT_COLLECTION_TOPICS_ENABLED &&
+      !TENANT_COLLECTION_TOPIC_QUALIFIER.matches(TENANT_COLLECTION_MATCH_REGEX)){
+      throw new RuntimeException(
+        String.format("%s environment variable does not match %s",
+          TENANT_COLLECTION_TOPICS_ENV_VAR_NAME,
+          TENANT_COLLECTION_MATCH_REGEX));
+    }
   }
 
   public String getTenant() {

--- a/mod-pubsub-server/src/main/java/org/folio/kafka/PubSubConfig.java
+++ b/mod-pubsub-server/src/main/java/org/folio/kafka/PubSubConfig.java
@@ -17,12 +17,15 @@ public class PubSubConfig {
   private String topicName;
 
   static {
-    tenantCollectionTopicQualifier = System.getenv(TENANT_COLLECTION_TOPICS_ENV_VAR_NAME);
+    setTenantCollectionTopicsQualifier();
+  }
+
+  public static void setTenantCollectionTopicsQualifier() {
     try {
-      setTenantCollectionTopicsQualifier(tenantCollectionTopicQualifier);
+      setTenantCollectionTopicsQualifier(System.getenv(TENANT_COLLECTION_TOPICS_ENV_VAR_NAME));
     } catch (IllegalArgumentException e) {
-      throw new IllegalArgumentException(String.format("%s environment variable value is not valid",
-        TENANT_COLLECTION_TOPICS_ENV_VAR_NAME), e);
+      throw new IllegalArgumentException(
+        String.format("%s environment variable: %s", TENANT_COLLECTION_TOPICS_ENV_VAR_NAME, e.getMessage()), e);
     }
   }
 
@@ -39,12 +42,12 @@ public class PubSubConfig {
 
   public static void setTenantCollectionTopicsQualifier(String value) {
     tenantCollectionTopicQualifier = value;
-    isTenantCollectionTopicsEnabled = !StringUtils.isEmpty(tenantCollectionTopicQualifier);
+    isTenantCollectionTopicsEnabled = StringUtils.isNotEmpty(tenantCollectionTopicQualifier);
 
     if (isTenantCollectionTopicsEnabled &&
       !tenantCollectionTopicQualifier.matches(TENANT_COLLECTION_MATCH_REGEX)) {
       throw new IllegalArgumentException(
-        String.format("Tenant collection qualifier not match %s",
+        String.format("Tenant collection qualifier doesn't match %s",
           TENANT_COLLECTION_MATCH_REGEX));
     }
   }

--- a/mod-pubsub-server/src/main/java/org/folio/services/cache/Cache.java
+++ b/mod-pubsub-server/src/main/java/org/folio/services/cache/Cache.java
@@ -7,6 +7,7 @@ import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import org.folio.dao.MessagingModuleDao;
 import org.folio.rest.jaxrs.model.MessagingModule;
+import org.folio.rest.util.OkapiConnectionParams;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -25,6 +26,7 @@ public class Cache {
   private AsyncLoadingCache<String, Set<MessagingModule>> loadingCache;
   private com.github.benmanes.caffeine.cache.Cache<String, String> subscriptions;
   private com.github.benmanes.caffeine.cache.Cache<String, String> tenantToken;
+  private com.github.benmanes.caffeine.cache.Cache<String, OkapiConnectionParams> knownOkapiParams;
   private MessagingModuleDao messagingModuleDao;
 
   public Cache(@Autowired Vertx vertx, @Autowired MessagingModuleDao messagingModuleDao) {
@@ -34,6 +36,7 @@ public class Cache {
       .buildAsync(k -> new HashSet<>());
     this.subscriptions = Caffeine.newBuilder().build();
     this.tenantToken = Caffeine.newBuilder().build();
+    this.knownOkapiParams = Caffeine.newBuilder().build();
   }
 
   public Future<Set<MessagingModule>> getMessagingModules() {
@@ -79,5 +82,13 @@ public class Cache {
 
   public void invalidateToken(String tenantId) {
     tenantToken.invalidate(tenantId);
+  }
+
+  public OkapiConnectionParams getKnownOkapiParams(String tenant) {
+    return knownOkapiParams.getIfPresent(tenant);
+  }
+
+  public void setKnownOkapiParams(String tenant, OkapiConnectionParams params) {
+    knownOkapiParams.put(tenant, params);
   }
 }

--- a/mod-pubsub-server/src/main/java/org/folio/services/impl/KafkaConsumerServiceImpl.java
+++ b/mod-pubsub-server/src/main/java/org/folio/services/impl/KafkaConsumerServiceImpl.java
@@ -97,7 +97,7 @@ public class KafkaConsumerServiceImpl implements ConsumerService {
           .onFailure(e ->
             LOGGER.error(format("Could not subscribe to some of the topic {%s}", topic), e));
       })
-      .collect(Collectors.toList());
+      .toList();
     return GenericCompositeFuture.all(futures).mapEmpty();
   }
 

--- a/mod-pubsub-server/src/main/java/org/folio/services/impl/KafkaConsumerServiceImpl.java
+++ b/mod-pubsub-server/src/main/java/org/folio/services/impl/KafkaConsumerServiceImpl.java
@@ -109,6 +109,7 @@ public class KafkaConsumerServiceImpl implements ConsumerService {
         String tenantId = event.getEventMetadata().getTenantId();
         if (StringUtils.isBlank(tenantId)) {
           LOGGER.error("Kafka record does not contain a tenant id.");
+          return;
         }
         LOGGER.info("Received {} event with id '{}'", event.getEventType(), event.getId());
         auditService.saveAuditMessage(constructJsonAuditMessage(event, tenantId, AuditMessage.State.RECEIVED));

--- a/mod-pubsub-server/src/test/java/org/folio/kafka/PubSubConfigTest.java
+++ b/mod-pubsub-server/src/test/java/org/folio/kafka/PubSubConfigTest.java
@@ -1,0 +1,27 @@
+package org.folio.kafka;
+
+import org.junit.After;
+import org.junit.Test;
+
+import java.util.function.Supplier;
+
+import static org.junit.Assert.*;
+
+public class PubSubConfigTest {
+  private Supplier<PubSubConfig> pubSubConfigSupplier = () -> new PubSubConfig("env", "tenant", "eventType");
+
+  @Test
+  public void checkTopicNameWhenTenantCollectionEnabled() {
+    PubSubConfig pubSubConfig = pubSubConfigSupplier.get();
+    assertTrue(pubSubConfig.getTopicName().contains("env.pub-sub.tenant.eventType"));
+
+    PubSubConfig.setTenantCollectionTopicsQualifier("ALL");
+    pubSubConfig = pubSubConfigSupplier.get();
+    assertTrue(pubSubConfig.getTopicName().contains("env.pub-sub.ALL.eventType"));
+  }
+
+  @After
+  public void after() {
+    PubSubConfig.setTenantCollectionTopicsQualifier(null);
+  }
+}

--- a/mod-pubsub-server/src/test/java/org/folio/kafka/PubSubConfigTest.java
+++ b/mod-pubsub-server/src/test/java/org/folio/kafka/PubSubConfigTest.java
@@ -20,16 +20,16 @@ public class PubSubConfigTest {
     assertTrue(pubSubConfig.getTopicName().contains("env.pub-sub.tenant.eventType"));
     assertTrue(pubSubConfig.getTopicName().contains(ENV + ".pub-sub." + TENANT + "." + EVENT_TYPE));
     assertTrue(pubSubConfig.getGroupId().contains(ENV + ".pub-sub." + TENANT + "." + EVENT_TYPE + ".mod-pubsub"));
-    assertEquals(pubSubConfig.getTenant(), TENANT);
-    assertEquals(pubSubConfig.getEventType(), EVENT_TYPE);
+    assertEquals(TENANT, pubSubConfig.getTenant());
+    assertEquals(EVENT_TYPE, pubSubConfig.getEventType());
 
     String qualifier = "ALL";
     PubSubConfig.setTenantCollectionTopicsQualifier(qualifier);
     pubSubConfig = pubSubConfigSupplier.get();
     assertTrue(pubSubConfig.getTopicName().contains(ENV + ".pub-sub." + qualifier + "." + EVENT_TYPE));
     assertTrue(pubSubConfig.getGroupId().contains(ENV + ".pub-sub." + qualifier + "." + EVENT_TYPE + ".mod-pubsub"));
-    assertEquals(pubSubConfig.getTenant(), TENANT);
-    assertEquals(pubSubConfig.getEventType(), EVENT_TYPE);
+    assertEquals(TENANT, pubSubConfig.getTenant());
+    assertEquals(EVENT_TYPE, pubSubConfig.getEventType());
   }
 
   @Test(expected = IllegalArgumentException.class)

--- a/mod-pubsub-server/src/test/java/org/folio/kafka/PubSubConfigTest.java
+++ b/mod-pubsub-server/src/test/java/org/folio/kafka/PubSubConfigTest.java
@@ -8,16 +8,32 @@ import java.util.function.Supplier;
 import static org.junit.Assert.*;
 
 public class PubSubConfigTest {
-  private Supplier<PubSubConfig> pubSubConfigSupplier = () -> new PubSubConfig("env", "tenant", "eventType");
+  private final String ENV = "env";
+  private final String EVENT_TYPE = "eventType";
+  private final String TENANT = "tenant";
+  private Supplier<PubSubConfig> pubSubConfigSupplier = () -> new PubSubConfig(ENV, TENANT, EVENT_TYPE);
 
   @Test
   public void checkTopicNameWhenTenantCollectionEnabled() {
     PubSubConfig pubSubConfig = pubSubConfigSupplier.get();
     assertTrue(pubSubConfig.getTopicName().contains("env.pub-sub.tenant.eventType"));
+    assertTrue(pubSubConfig.getTopicName().contains(ENV + ".pub-sub." + TENANT + "." + EVENT_TYPE));
+    assertTrue(pubSubConfig.getGroupId().contains(ENV + ".pub-sub." + TENANT + "." + EVENT_TYPE + ".mod-pubsub"));
+    assertEquals(pubSubConfig.getTenant(), TENANT);
+    assertEquals(pubSubConfig.getEventType(), EVENT_TYPE);
 
-    PubSubConfig.setTenantCollectionTopicsQualifier("ALL");
+    String qualifier = "ALL";
+    PubSubConfig.setTenantCollectionTopicsQualifier(qualifier);
     pubSubConfig = pubSubConfigSupplier.get();
-    assertTrue(pubSubConfig.getTopicName().contains("env.pub-sub.ALL.eventType"));
+    assertTrue(pubSubConfig.getTopicName().contains(ENV + ".pub-sub." + qualifier + "." + EVENT_TYPE));
+    assertTrue(pubSubConfig.getGroupId().contains(ENV + ".pub-sub." + qualifier + "." + EVENT_TYPE + ".mod-pubsub"));
+    assertEquals(pubSubConfig.getTenant(), TENANT);
+    assertEquals(pubSubConfig.getEventType(), EVENT_TYPE);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void checkQualifierMatchesRegex() {
+    PubSubConfig.setTenantCollectionTopicsQualifier("bad_value");
   }
 
   @After

--- a/mod-pubsub-server/src/test/java/org/folio/kafka/PubSubConfigTest.java
+++ b/mod-pubsub-server/src/test/java/org/folio/kafka/PubSubConfigTest.java
@@ -1,16 +1,17 @@
 package org.folio.kafka;
 
-import org.junit.After;
-import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.util.function.Supplier;
 
-import static org.junit.Assert.*;
+import org.junit.After;
+import org.junit.Test;
 
 public class PubSubConfigTest {
-  private final String ENV = "env";
-  private final String EVENT_TYPE = "eventType";
-  private final String TENANT = "tenant";
+  private static final String ENV = "env";
+  private static final String EVENT_TYPE = "eventType";
+  private static final String TENANT = "tenant";
   private Supplier<PubSubConfig> pubSubConfigSupplier = () -> new PubSubConfig(ENV, TENANT, EVENT_TYPE);
 
   @Test

--- a/mod-pubsub-server/src/test/java/org/folio/rest/impl/AbstractRestTest.java
+++ b/mod-pubsub-server/src/test/java/org/folio/rest/impl/AbstractRestTest.java
@@ -1,16 +1,15 @@
 package org.folio.rest.impl;
 
-import io.restassured.builder.RequestSpecBuilder;
-import io.restassured.http.ContentType;
-import io.restassured.specification.RequestSpecification;
-import io.vertx.core.DeploymentOptions;
-import io.vertx.core.Future;
-import io.vertx.core.Vertx;
-import io.vertx.core.json.JsonObject;
-import io.vertx.ext.unit.Async;
-import io.vertx.ext.unit.TestContext;
-import io.vertx.kafka.admin.KafkaAdminClient;
-import io.vertx.sqlclient.Tuple;
+import static java.lang.String.format;
+import static org.folio.rest.RestVerticle.OKAPI_HEADER_TENANT;
+import static org.testcontainers.shaded.org.awaitility.Awaitility.await;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Supplier;
+
 import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.folio.postgres.testing.PostgresTesterContainer;
 import org.folio.rest.RestVerticle;
@@ -27,16 +26,16 @@ import org.junit.BeforeClass;
 import org.testcontainers.containers.KafkaContainer;
 import org.testcontainers.utility.DockerImageName;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.Supplier;
-
-import static java.lang.String.format;
-import static org.folio.rest.RestVerticle.OKAPI_HEADER_TENANT;
-import static org.testcontainers.shaded.org.awaitility.Awaitility.await;
+import io.restassured.builder.RequestSpecBuilder;
+import io.restassured.http.ContentType;
+import io.restassured.specification.RequestSpecification;
+import io.vertx.core.DeploymentOptions;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.kafka.admin.KafkaAdminClient;
+import io.vertx.sqlclient.Tuple;
 
 public abstract class AbstractRestTest {
   protected static final String TENANT_ID = "diku";

--- a/mod-pubsub-server/src/test/java/org/folio/rest/impl/AbstractRestTest.java
+++ b/mod-pubsub-server/src/test/java/org/folio/rest/impl/AbstractRestTest.java
@@ -214,6 +214,7 @@ public abstract class AbstractRestTest {
     await()
       .atMost(15, TimeUnit.SECONDS)
       .pollInterval(3, TimeUnit.SECONDS)
+      .alias("Is Postgres Up?")
       .until(() -> {
         System.out.println("checking to see if postgres is up");
 
@@ -226,19 +227,19 @@ public abstract class AbstractRestTest {
     if (!isReady.get()) throw new RuntimeException("Could not connect to postgres");
   }
 
-  private static void waitForKafka(){
+  private static void waitForKafka() {
     Supplier<KafkaAdminClient> buildAdminClient = () -> {
       Map<String, String> configs = new HashMap<>();
       configs.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaContainer.getBootstrapServers());
       return KafkaAdminClient.create(vertx, configs);
     };
-    AtomicReference<Future<Boolean>> futureAtomicReference = new AtomicReference<>(Future.succeededFuture(false));
+    AtomicBoolean isReady = new AtomicBoolean();
 
     await()
       .atMost(15, TimeUnit.SECONDS)
       .pollDelay(3, TimeUnit.SECONDS)
       .pollInterval(3, TimeUnit.SECONDS)
-      .alias("Is Kafka up?")
+      .alias("Is Kafka Up?")
       .until(() -> {
         System.out.println("listing topics to see if kafka is up");
         KafkaAdminClient adminClient = buildAdminClient.get();
@@ -246,11 +247,11 @@ public abstract class AbstractRestTest {
           .onComplete(ar -> {
             if (ar.succeeded()) {
               System.out.println("Kafka is up");
-              futureAtomicReference.set(Future.succeededFuture(true));
+              isReady.set(true);
             }
             adminClient.close(1000);
           });
-        return futureAtomicReference.get().result();
+        return isReady.get();
       });
   }
 }

--- a/mod-pubsub-server/src/test/java/org/folio/rest/impl/AbstractRestTest.java
+++ b/mod-pubsub-server/src/test/java/org/folio/rest/impl/AbstractRestTest.java
@@ -4,11 +4,15 @@ import io.restassured.builder.RequestSpecBuilder;
 import io.restassured.http.ContentType;
 import io.restassured.specification.RequestSpecification;
 import io.vertx.core.DeploymentOptions;
+import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
+import io.vertx.kafka.admin.KafkaAdminClient;
 import io.vertx.sqlclient.Tuple;
+import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.folio.postgres.testing.PostgresTesterContainer;
 import org.folio.rest.RestVerticle;
 import org.folio.rest.client.TenantClient;
 import org.folio.rest.jaxrs.model.TenantAttributes;
@@ -16,7 +20,6 @@ import org.folio.rest.jaxrs.model.TenantJob;
 import org.folio.rest.persist.Criteria.Criterion;
 import org.folio.rest.persist.PostgresClient;
 import org.folio.rest.tools.utils.ModuleName;
-import org.folio.postgres.testing.PostgresTesterContainer;
 import org.folio.rest.tools.utils.NetworkUtils;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -24,8 +27,16 @@ import org.junit.BeforeClass;
 import org.testcontainers.containers.KafkaContainer;
 import org.testcontainers.utility.DockerImageName;
 
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+
 import static java.lang.String.format;
 import static org.folio.rest.RestVerticle.OKAPI_HEADER_TENANT;
+import static org.testcontainers.shaded.org.awaitility.Awaitility.await;
 
 public abstract class AbstractRestTest {
   protected static final String TENANT_ID = "diku";
@@ -68,17 +79,17 @@ public abstract class AbstractRestTest {
     vertx = Vertx.vertx();
     runDatabase();
     kafkaContainer.start();
+
     System.setProperty(KAFKA_HOST, kafkaContainer.getHost());
     System.setProperty(KAFKA_PORT, String.valueOf(kafkaContainer.getFirstMappedPort()));
     System.setProperty(OKAPI_URL_ENV, OKAPI_URL);
     System.setProperty(SYSTEM_USER_NAME_ENV, SYSTEM_USER_NAME);
     System.setProperty(SYSTEM_USER_PASSWORD_ENV, SYSTEM_USER_PASSWORD);
-    deployVerticle(context);
-  }
 
-  @AfterClass
-  public static void tearDownClass() {
-    kafkaContainer.stop();
+    waitForPostgres();
+    waitForKafka();
+
+    deployVerticle(context);
   }
 
   private static void runDatabase() throws Exception {
@@ -154,6 +165,7 @@ public abstract class AbstractRestTest {
       }
       System.clearProperty(KAFKA_HOST);
       System.clearProperty(KAFKA_PORT);
+      kafkaContainer.stop();
       async.complete();
     }));
   }
@@ -165,7 +177,7 @@ public abstract class AbstractRestTest {
     spec = new RequestSpecBuilder()
       .setContentType(ContentType.JSON)
       .addHeader(OKAPI_HEADER_TENANT, TENANT_ID)
-      .setBaseUri("http://localhost:" + PORT)
+      .setBaseUri(OKAPI_URL)
       .addHeader("Accept", "text/plain, application/json")
       .build();
   }
@@ -193,5 +205,52 @@ public abstract class AbstractRestTest {
         async.complete();
       });
     });
+  }
+
+  private static void waitForPostgres() {
+    PostgresClient pgClient = PostgresClient.getInstance(vertx);
+    String query = "Select 1";
+    AtomicBoolean isReady = new AtomicBoolean();
+    await()
+      .atMost(15, TimeUnit.SECONDS)
+      .pollInterval(3, TimeUnit.SECONDS)
+      .until(() -> {
+        System.out.println("checking to see if postgres is up");
+
+        vertx.runOnContext((at) -> pgClient.select(query)
+          .onSuccess(ar -> isReady.set(true)));
+
+        return isReady.get();
+      });
+
+    if (!isReady.get()) throw new RuntimeException("Could not connect to postgres");
+  }
+
+  private static void waitForKafka(){
+    Supplier<KafkaAdminClient> buildAdminClient = () -> {
+      Map<String, String> configs = new HashMap<>();
+      configs.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaContainer.getBootstrapServers());
+      return KafkaAdminClient.create(vertx, configs);
+    };
+    AtomicReference<Future<Boolean>> futureAtomicReference = new AtomicReference<>(Future.succeededFuture(false));
+
+    await()
+      .atMost(15, TimeUnit.SECONDS)
+      .pollDelay(3, TimeUnit.SECONDS)
+      .pollInterval(3, TimeUnit.SECONDS)
+      .alias("Is Kafka up?")
+      .until(() -> {
+        System.out.println("listing topics to see if kafka is up");
+        KafkaAdminClient adminClient = buildAdminClient.get();
+        adminClient.listTopics()
+          .onComplete(ar -> {
+            if (ar.succeeded()) {
+              System.out.println("Kafka is up");
+              futureAtomicReference.set(Future.succeededFuture(true));
+            }
+            adminClient.close(1000);
+          });
+        return futureAtomicReference.get().result();
+      });
   }
 }

--- a/mod-pubsub-server/src/test/java/org/folio/rest/impl/PublishTest.java
+++ b/mod-pubsub-server/src/test/java/org/folio/rest/impl/PublishTest.java
@@ -7,6 +7,7 @@ import io.restassured.response.Response;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import org.apache.http.HttpStatus;
+import org.folio.kafka.PubSubConfig;
 import org.folio.rest.jaxrs.model.EventDescriptor;
 import org.folio.rest.jaxrs.model.PublisherDescriptor;
 import org.folio.rest.jaxrs.model.SubscriberDescriptor;
@@ -103,7 +104,7 @@ public class PublishTest extends AbstractRestTest {
     registerSubscriber(eventDescriptor);
 
     // wait for kafka subscription to settle down
-    Thread.sleep(3000);
+    Thread.sleep(3000); //NOSONAR
 
     RestAssured.given()
       .spec(spec)
@@ -121,6 +122,16 @@ public class PublishTest extends AbstractRestTest {
       .untilAsserted(() -> {
         System.out.println("Asserting subscriber notification...");
         verify(postRequestedFor(urlEqualTo(CALLBACK_ADDRESS)));});
+  }
+
+  @Test
+  public void shouldPublishEventWithPayloadAndTenantCollectionTopicsEnabled() throws InterruptedException {
+    try {
+      PubSubConfig.setTenantCollectionTopicsQualifier("ALL");
+      shouldPublishEventWithPayload();
+    } finally {
+      PubSubConfig.setTenantCollectionTopicsQualifier(null);
+    }
   }
 
   private void registerPublisher(EventDescriptor eventDescriptor) {

--- a/mod-pubsub-server/src/test/java/org/folio/rest/impl/PublishTest.java
+++ b/mod-pubsub-server/src/test/java/org/folio/rest/impl/PublishTest.java
@@ -1,5 +1,7 @@
 package org.folio.rest.impl;
 
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import io.restassured.RestAssured;
 import io.restassured.response.Response;
 import io.vertx.core.json.JsonObject;
@@ -10,19 +12,37 @@ import org.folio.rest.jaxrs.model.PublisherDescriptor;
 import org.folio.rest.jaxrs.model.SubscriberDescriptor;
 import org.folio.rest.jaxrs.model.SubscriptionDefinition;
 import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import java.util.Collections;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.any;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
+import static org.awaitility.Awaitility.await;
+import static org.folio.rest.util.OkapiConnectionParams.OKAPI_TOKEN_HEADER;
+import static org.folio.rest.util.OkapiConnectionParams.OKAPI_URL_HEADER;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
 @RunWith(VertxUnitRunner.class)
 public class PublishTest extends AbstractRestTest {
-
+  @ClassRule
+  public static WireMockRule wireMockRule = new WireMockRule(
+    new WireMockConfiguration().dynamicPort());
   private static final String PUBLISH_PATH = "/pubsub/publish";
+  private static final String CALLBACK_ADDRESS = "/call-me-maybe";
+  private static final String LOGIN_URL = "/authn/login";
+  private static final String USERS_URL = "/users";
+  private static final String GET_PUBSUB_USER_URL = USERS_URL + "?query=username=" + SYSTEM_USER_NAME;
   private static final EventDescriptor EVENT_DESCRIPTOR = new EventDescriptor()
     .withEventType("record_created")
     .withDescription("Created SRS Marc Bibliographic Record with order data in 9xx fields")
@@ -77,10 +97,13 @@ public class PublishTest extends AbstractRestTest {
   }
 
   @Test
-  public void shouldPublishEventWithPayload() {
+  public void shouldPublishEventWithPayload() throws InterruptedException {
     EventDescriptor eventDescriptor = postEventDescriptor(EVENT_DESCRIPTOR);
     registerPublisher(eventDescriptor);
     registerSubscriber(eventDescriptor);
+
+    // wait for kafka subscription to settle down
+    Thread.sleep(3000);
 
     RestAssured.given()
       .spec(spec)
@@ -89,6 +112,15 @@ public class PublishTest extends AbstractRestTest {
       .post(PUBLISH_PATH)
       .then()
       .statusCode(HttpStatus.SC_NO_CONTENT);
+
+    String methodName = Thread.currentThread().getStackTrace()[1].getMethodName();
+    await()
+      .atMost(15, TimeUnit.SECONDS)
+      .alias(methodName)
+      .pollInterval(3, TimeUnit.SECONDS)
+      .untilAsserted(() -> {
+        System.out.println("Asserting subscriber notification...");
+        verify(postRequestedFor(urlEqualTo(CALLBACK_ADDRESS)));});
   }
 
   private void registerPublisher(EventDescriptor eventDescriptor) {
@@ -118,18 +150,40 @@ public class PublishTest extends AbstractRestTest {
   private void registerSubscriber(EventDescriptor eventDescriptor) {
     SubscriptionDefinition subscriptionDefinition = new SubscriptionDefinition()
       .withEventType(eventDescriptor.getEventType())
-      .withCallbackAddress("/call-me-maybe");
+      .withCallbackAddress(CALLBACK_ADDRESS);
     SubscriberDescriptor subscriberDescriptor = new SubscriberDescriptor()
       .withSubscriptionDefinitions(Collections.singletonList(subscriptionDefinition))
       .withModuleId("mod-important-1.0.0");
 
     RestAssured.given()
-      .spec(spec)
+      .spec(spec.header(OKAPI_URL_HEADER, mockOkapiUrl()))
       .body(JsonObject.mapFrom(subscriberDescriptor).encode())
       .when()
       .post(EVENT_TYPES_PATH + DECLARE_SUBSCRIBER_PATH)
       .then()
       .statusCode(HttpStatus.SC_CREATED);
+  }
+
+  @Before
+  public void setUp(){
+    wireMockRule.stubFor(any(urlEqualTo(CALLBACK_ADDRESS)));
+    wireMockRule.stubFor(post(urlEqualTo(GET_PUBSUB_USER_URL))
+      .willReturn(aResponse()
+        .withBody("{\n" +
+          "    \"users\": [\n" +
+          "        {\n" +
+          "            \"username\": \"test-pubsub-username\",\n" +
+          "            \"id\": \"5a05e962-0502-5f78-a1fb-c47ba902298b\",\n" +
+          "            \"active\": true,\n" +
+          "            \"patronGroup\": \"3684a786-6671-4268-8ed0-9db82ebca60b\"\n" +
+          "        }\n" +
+          "    ],\n" +
+          "    \"totalRecords\": 1\n" +
+          "}")));
+    wireMockRule.stubFor(post(urlEqualTo(LOGIN_URL))
+      .willReturn(aResponse()
+        .withHeader(OKAPI_TOKEN_HEADER, "okapi_token")
+        .withStatus(201)));
   }
 
   @After
@@ -148,5 +202,9 @@ public class PublishTest extends AbstractRestTest {
       .delete(EVENT_TYPES_PATH + "/record_created" + SUBSCRIBERS_PATH)
       .then()
       .statusCode(HttpStatus.SC_NO_CONTENT);
+  }
+
+  private String mockOkapiUrl() {
+    return "http://localhost:"+ wireMockRule.port();
   }
 }


### PR DESCRIPTION
## Purpose
To reduce the number of partitions needed for a FOLIO cluster with a large number of tenants, mod-pubsub will publish messages to a single topic per event type instead of multiple topics for each tenant.

## Approach
Modify PubSubConfig to output a tenant collection topic is a environment variable is set. The default operation is to produce messages to topics for each tenant.

## Learning
https://issues.folio.org/browse/MODPUBSUB-270
