### PR TITLE
MODPUBSUB-267: Use new RMB read-only APIs

### DIFF
--- a/mod-pubsub-server/src/main/java/org/folio/dao/impl/AuditMessageDaoImpl.java
+++ b/mod-pubsub-server/src/main/java/org/folio/dao/impl/AuditMessageDaoImpl.java
@@ -51,7 +51,7 @@ public class AuditMessageDaoImpl implements AuditMessageDao {
     try {
       String query = format(SELECT_QUERY, convertToPsqlStandard(tenantId), AUDIT_MESSAGE_TABLE)
         .concat(constructWhereClauseForGetAuditMessagesQuery(filter));
-      pgClientFactory.getInstance(tenantId).select(query, promise);
+      pgClientFactory.getInstance(tenantId).selectRead(query, 0, promise);
     } catch (Exception e) {
       LOGGER.error("Error retrieving audit messages", e);
       promise.fail(e);

--- a/mod-pubsub-server/src/main/java/org/folio/dao/impl/AuditMessageDaoImpl.java
+++ b/mod-pubsub-server/src/main/java/org/folio/dao/impl/AuditMessageDaoImpl.java
@@ -102,7 +102,7 @@ public class AuditMessageDaoImpl implements AuditMessageDao {
     Promise<RowSet<Row>> promise = Promise.promise();
     try {
       String query = format(GET_BY_EVENT_ID_QUERY, convertToPsqlStandard(tenantId), AUDIT_MESSAGE_PAYLOAD_TABLE);
-      pgClientFactory.getInstance(tenantId).select(query, Tuple.of(UUID.fromString(eventId)), promise);
+      pgClientFactory.getInstance(tenantId).selectRead(query, Tuple.of(UUID.fromString(eventId)), promise);
     } catch (Exception e) {
       LOGGER.error("Error while searching for audit message payload by event id {}", eventId, e);
       promise.fail(e);

--- a/mod-pubsub-server/src/main/java/org/folio/dao/impl/EventDescriptorDaoImpl.java
+++ b/mod-pubsub-server/src/main/java/org/folio/dao/impl/EventDescriptorDaoImpl.java
@@ -48,7 +48,7 @@ public class EventDescriptorDaoImpl implements EventDescriptorDao {
   public Future<List<EventDescriptor>> getAll() {
     Promise<RowSet<Row>> promise = Promise.promise();
     String preparedQuery = format(GET_ALL_SQL, MODULE_SCHEMA, TABLE_NAME);
-    pgClientFactory.getInstance().select(preparedQuery, promise);
+    pgClientFactory.getInstance().selectRead(preparedQuery, 0, promise);
     return promise.future().map(this::mapResultSetToEventDescriptorList);
   }
 
@@ -71,7 +71,7 @@ public class EventDescriptorDaoImpl implements EventDescriptorDao {
     Promise<RowSet<Row>> promise = Promise.promise();
     String query = getQueryByEventTypes(eventTypes);
     String preparedQuery = format(query, MODULE_SCHEMA, TABLE_NAME);
-    pgClientFactory.getInstance().select(preparedQuery, promise);
+    pgClientFactory.getInstance().selectRead(preparedQuery, 0, promise);
     return promise.future().map(this::mapResultSetToEventDescriptorList);
   }
 

--- a/mod-pubsub-server/src/main/java/org/folio/dao/impl/EventDescriptorDaoImpl.java
+++ b/mod-pubsub-server/src/main/java/org/folio/dao/impl/EventDescriptorDaoImpl.java
@@ -57,7 +57,7 @@ public class EventDescriptorDaoImpl implements EventDescriptorDao {
     Promise<RowSet<Row>> promise = Promise.promise();
     try {
       String preparedQuery = format(GET_BY_ID_SQL, MODULE_SCHEMA, TABLE_NAME);
-      pgClientFactory.getInstance().select(preparedQuery, Tuple.of(eventType), promise);
+      pgClientFactory.getInstance().selectRead(preparedQuery, Tuple.of(eventType), promise);
     } catch (Exception e) {
       LOGGER.error("Error getting EventDescriptor by event type '{}'", eventType, e);
       promise.fail(e);

--- a/mod-pubsub-server/src/main/java/org/folio/dao/impl/MessagingModuleDaoImpl.java
+++ b/mod-pubsub-server/src/main/java/org/folio/dao/impl/MessagingModuleDaoImpl.java
@@ -53,7 +53,7 @@ public class MessagingModuleDaoImpl implements MessagingModuleDao {
   public Future<List<MessagingModule>> get(MessagingModuleFilter filter) {
     Promise<RowSet<Row>> promise = Promise.promise();
     String preparedQuery = format(GET_BY_SQL, MODULE_SCHEMA, TABLE_NAME, buildWhereClause(filter));
-    pgClientFactory.getInstance().select(preparedQuery, 0, promise);
+    pgClientFactory.getInstance().selectRead(preparedQuery, 0, promise);
     return promise.future().map(this::mapResultSetToMessagingModuleList);
   }
 

--- a/mod-pubsub-server/src/main/java/org/folio/dao/impl/MessagingModuleDaoImpl.java
+++ b/mod-pubsub-server/src/main/java/org/folio/dao/impl/MessagingModuleDaoImpl.java
@@ -53,7 +53,7 @@ public class MessagingModuleDaoImpl implements MessagingModuleDao {
   public Future<List<MessagingModule>> get(MessagingModuleFilter filter) {
     Promise<RowSet<Row>> promise = Promise.promise();
     String preparedQuery = format(GET_BY_SQL, MODULE_SCHEMA, TABLE_NAME, buildWhereClause(filter));
-    pgClientFactory.getInstance().select(preparedQuery, promise);
+    pgClientFactory.getInstance().select(preparedQuery, 0, promise);
     return promise.future().map(this::mapResultSetToMessagingModuleList);
   }
 
@@ -113,7 +113,7 @@ public class MessagingModuleDaoImpl implements MessagingModuleDao {
   public Future<List<MessagingModule>> getAll() {
     Promise<RowSet<Row>> promise = Promise.promise();
     String preparedQuery = format(GET_ALL_SQL, MODULE_SCHEMA, TABLE_NAME);
-    pgClientFactory.getInstance().select(preparedQuery, promise);
+    pgClientFactory.getInstance().selectRead(preparedQuery, 0, promise);
     return promise.future().map(this::mapResultSetToMessagingModuleList);
   }
 

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
   </modules>
 
   <properties>
-    <raml-module-builder.version>35.0.1</raml-module-builder.version>
+    <raml-module-builder.version>35.0.6</raml-module-builder.version>
     <vertx.version>4.3.4</vertx.version>
     <lombok.version>1.18.28</lombok.version>
     <wiremock.version>2.27.2</wiremock.version>


### PR DESCRIPTION
## Purpose
Use new RMB read-only APIs in order to benefit from read-write DB access split.
Resolves [MODPUBSUB-267](https://issues.folio.org/browse/MODPUBSUB-267).

## Approach
Follow guide provided in [FOLIO-3753](https://issues.folio.org/browse/FOLIO-3753).

#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.

## Learning
_Describe the research stage. Add links to blog posts, patterns, libraries or addons used to solve this problem._
