### PR TITLE
MODPUBSUB-274. Populate system users with type='system'

### DIFF
--- a/mod-pubsub-server/src/main/java/org/folio/representation/User.java
+++ b/mod-pubsub-server/src/main/java/org/folio/representation/User.java
@@ -9,10 +9,19 @@ import com.fasterxml.jackson.annotation.JsonAnySetter;
 public class User {
   private String id;
   private String username;
+  private String type;
   private boolean active;
   private Personal personal;
   // Everything else that we're not expecting, just in case
   private final Map<String, Object> unmapped = new HashMap<>();
+
+  public String getType() {
+    return type;
+  }
+
+  public void setType(String type) {
+    this.type = type;
+  }
 
   public String getId() {
     return id;

--- a/mod-pubsub-server/src/main/java/org/folio/services/impl/SecurityManagerImpl.java
+++ b/mod-pubsub-server/src/main/java/org/folio/services/impl/SecurityManagerImpl.java
@@ -54,7 +54,7 @@ public class SecurityManagerImpl implements SecurityManager {
   private static final List<String> PERMISSIONS = readPermissionsFromResource(PERMISSIONS_FILE_PATH);
   private static final String ACCESS_TOKEN_NAME = "folioAccessToken";
   private static final String REFRESH_TOKEN_NAME = "folioRefreshToken";
-  public static final String SYSTEM_USER_TYPE = "system";
+  private static final String SYSTEM_USER_TYPE = "system";
 
   private final Cache cache;
   private final SystemUserConfig systemUserConfig;

--- a/mod-pubsub-server/src/main/java/org/folio/services/impl/SecurityManagerImpl.java
+++ b/mod-pubsub-server/src/main/java/org/folio/services/impl/SecurityManagerImpl.java
@@ -36,7 +36,6 @@ import com.google.common.io.Resources;
 
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
-import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
@@ -55,7 +54,7 @@ public class SecurityManagerImpl implements SecurityManager {
   private static final List<String> PERMISSIONS = readPermissionsFromResource(PERMISSIONS_FILE_PATH);
   private static final String ACCESS_TOKEN_NAME = "folioAccessToken";
   private static final String REFRESH_TOKEN_NAME = "folioRefreshToken";
-  private static final String SYSTEM_USER_TYPE = "system";
+  public static final String SYSTEM_USER_TYPE = "system";
 
   private final Cache cache;
   private final SystemUserConfig systemUserConfig;

--- a/mod-pubsub-server/src/main/java/org/folio/services/impl/SecurityManagerImpl.java
+++ b/mod-pubsub-server/src/main/java/org/folio/services/impl/SecurityManagerImpl.java
@@ -366,14 +366,12 @@ public class SecurityManagerImpl implements SecurityManager {
 
   private boolean existingUserUpToDate(User existingUser) {
     return existingUser.getPersonal() != null
-      && isNotBlank(existingUser.getPersonal().getLastName())
-      && SYSTEM_USER_TYPE.equals(existingUser.getType());
+      && isNotBlank(existingUser.getPersonal().getLastName());
   }
 
   private User populateMissingUserProperties(User existingUser) {
     existingUser.setPersonal(new User.Personal());
     existingUser.getPersonal().setLastName(USER_LAST_NAME);
-    existingUser.setType(SYSTEM_USER_TYPE);
 
     return existingUser;
   }

--- a/mod-pubsub-server/src/main/java/org/folio/services/impl/SecurityManagerImpl.java
+++ b/mod-pubsub-server/src/main/java/org/folio/services/impl/SecurityManagerImpl.java
@@ -55,6 +55,7 @@ public class SecurityManagerImpl implements SecurityManager {
   private static final List<String> PERMISSIONS = readPermissionsFromResource(PERMISSIONS_FILE_PATH);
   private static final String ACCESS_TOKEN_NAME = "folioAccessToken";
   private static final String REFRESH_TOKEN_NAME = "folioRefreshToken";
+  private static final String SYSTEM_USER_TYPE = "system";
 
   private final Cache cache;
   private final SystemUserConfig systemUserConfig;
@@ -355,6 +356,7 @@ public class SecurityManagerImpl implements SecurityManager {
     user.setId(UUID.randomUUID().toString());
     user.setActive(true);
     user.setUsername(systemUserConfig.getName());
+    user.setType(SYSTEM_USER_TYPE);
 
     user.setPersonal(new User.Personal());
     user.getPersonal().setLastName(USER_LAST_NAME);
@@ -364,12 +366,14 @@ public class SecurityManagerImpl implements SecurityManager {
 
   private boolean existingUserUpToDate(User existingUser) {
     return existingUser.getPersonal() != null
-      && isNotBlank(existingUser.getPersonal().getLastName());
+      && isNotBlank(existingUser.getPersonal().getLastName())
+      && SYSTEM_USER_TYPE.equals(existingUser.getType());
   }
 
   private User populateMissingUserProperties(User existingUser) {
     existingUser.setPersonal(new User.Personal());
     existingUser.getPersonal().setLastName(USER_LAST_NAME);
+    existingUser.setType(SYSTEM_USER_TYPE);
 
     return existingUser;
   }

--- a/mod-pubsub-server/src/test/java/org/folio/rest/impl/AbstractRestTest.java
+++ b/mod-pubsub-server/src/test/java/org/folio/rest/impl/AbstractRestTest.java
@@ -66,6 +66,7 @@ public abstract class AbstractRestTest {
   protected static final String SYSTEM_USER_PASSWORD_ENV = "SYSTEM_USER_PASSWORD";
   protected static final String SYSTEM_USER_NAME = "test-pubsub-username";
   protected static final String SYSTEM_USER_PASSWORD = "test-pubsub-password";
+  protected static final String SYSTEM_USER_TYPE = "system";
 
   static RequestSpecification spec;
   private static String useExternalDatabase;

--- a/mod-pubsub-server/src/test/java/org/folio/rest/impl/ModTenantApiTest.java
+++ b/mod-pubsub-server/src/test/java/org/folio/rest/impl/ModTenantApiTest.java
@@ -3,18 +3,13 @@ package org.folio.rest.impl;
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.any;
 import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
-import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
-import static com.github.tomakehurst.wiremock.client.WireMock.ok;
 import static com.github.tomakehurst.wiremock.client.WireMock.okJson;
-import static com.github.tomakehurst.wiremock.client.WireMock.post;
-import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+
 import static com.github.tomakehurst.wiremock.client.WireMock.put;
-import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
-import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
-import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 import static java.lang.String.format;
 import static org.folio.rest.util.OkapiConnectionParams.OKAPI_URL_HEADER;
+import static org.folio.services.impl.SecurityManagerImpl.SYSTEM_USER_TYPE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -79,6 +74,7 @@ public class ModTenantApiTest extends AbstractRestTest {
 
     user.setId(UUID.randomUUID().toString());
     user.setActive(true);
+    user.setType(SYSTEM_USER_TYPE);
     user.setUsername(SYSTEM_USER_NAME);
 
     return user;

--- a/mod-pubsub-server/src/test/java/org/folio/rest/impl/ModTenantApiTest.java
+++ b/mod-pubsub-server/src/test/java/org/folio/rest/impl/ModTenantApiTest.java
@@ -9,7 +9,6 @@ import static com.github.tomakehurst.wiremock.client.WireMock.okJson;
 import static com.github.tomakehurst.wiremock.client.WireMock.put;
 import static java.lang.String.format;
 import static org.folio.rest.util.OkapiConnectionParams.OKAPI_URL_HEADER;
-import static org.folio.services.impl.SecurityManagerImpl.SYSTEM_USER_TYPE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 

--- a/mod-pubsub-server/src/test/java/org/folio/services/impl/SecurityManagerTest.java
+++ b/mod-pubsub-server/src/test/java/org/folio/services/impl/SecurityManagerTest.java
@@ -21,7 +21,6 @@ import static java.lang.String.format;
 import static org.folio.rest.util.OkapiConnectionParams.OKAPI_TENANT_HEADER;
 import static org.folio.rest.util.OkapiConnectionParams.OKAPI_TOKEN_HEADER;
 import static org.folio.rest.util.OkapiConnectionParams.OKAPI_URL_HEADER;
-import static org.folio.services.impl.SecurityManagerImpl.SYSTEM_USER_TYPE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -71,6 +70,7 @@ import io.vertx.ext.unit.junit.VertxUnitRunner;
 public class SecurityManagerTest {
   protected static final String SYSTEM_USER_NAME = "test-pubsub-username";
   protected static final String SYSTEM_USER_PASSWORD = "test-pubsub-password";
+  protected static final String SYSTEM_USER_TYPE = "system";
 
   private static final String LOGIN_URL = "/authn/login-with-expiry";
   private static final String USERS_URL = "/users";

--- a/mod-pubsub-server/src/test/java/org/folio/services/impl/SecurityManagerTest.java
+++ b/mod-pubsub-server/src/test/java/org/folio/services/impl/SecurityManagerTest.java
@@ -511,7 +511,7 @@ public class SecurityManagerTest {
       .put("lastName", "System")
       .put("addresses", new JsonArray());
 
-    return existingUser(id).put("type", "system").put("personal", personal);
+    return existingUser(id).put("type", SYSTEM_USER_TYPE).put("personal", personal);
   }
 
   private JsonObject emptyUsersResponse() {

--- a/mod-pubsub-server/src/test/java/org/folio/services/impl/SecurityManagerTest.java
+++ b/mod-pubsub-server/src/test/java/org/folio/services/impl/SecurityManagerTest.java
@@ -21,6 +21,7 @@ import static java.lang.String.format;
 import static org.folio.rest.util.OkapiConnectionParams.OKAPI_TENANT_HEADER;
 import static org.folio.rest.util.OkapiConnectionParams.OKAPI_TOKEN_HEADER;
 import static org.folio.rest.util.OkapiConnectionParams.OKAPI_URL_HEADER;
+import static org.folio.services.impl.SecurityManagerImpl.SYSTEM_USER_TYPE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -498,6 +499,7 @@ public class SecurityManagerTest {
       .put("id", id)
       .put("username", SYSTEM_USER_NAME)
       .put("active", "true")
+      .put("type", SYSTEM_USER_TYPE)
       .put("proxyFor", new JsonArray())
       .put("createdDate", Instant.now())
       .put("updatedDate", Instant.now())

--- a/mod-pubsub-server/src/test/java/org/folio/services/impl/SecurityManagerTest.java
+++ b/mod-pubsub-server/src/test/java/org/folio/services/impl/SecurityManagerTest.java
@@ -509,7 +509,7 @@ public class SecurityManagerTest {
       .put("lastName", "System")
       .put("addresses", new JsonArray());
 
-    return existingUser(id).put("personal", personal);
+    return existingUser(id).put("type", "system").put("personal", personal);
   }
 
   private JsonObject emptyUsersResponse() {


### PR DESCRIPTION
## Purpose
https://issues.folio.org/browse/MODPUBSUB-274

## Approach
User type field is required in ECS mode, corresponding changes:
https://github.com/folio-org/mod-users/pull/305/files#diff-c61ac265e749725833c34e88681dd23fd2c267c2de0c62217a27526f50395772L3 

For non ECS mode it is optional, existing system users updated in scope of this PR:
https://github.com/folio-org/mod-users/pull/307