### PR TITLE
MODPUBSUB-279: Upgrade to RMB 35.1.0 and Vertx 4.4.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,8 +19,8 @@
   </modules>
 
   <properties>
-    <raml-module-builder.version>35.0.6</raml-module-builder.version>
-    <vertx.version>4.3.4</vertx.version>
+    <raml-module-builder.version>35.1.0</raml-module-builder.version>
+    <vertx.version>4.4.6</vertx.version>
     <lombok.version>1.18.28</lombok.version>
     <wiremock.version>2.27.2</wiremock.version>
     <junit.version>4.13.2</junit.version>
@@ -36,7 +36,7 @@
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-bom</artifactId>
-        <version>2.18.0</version>
+        <version>2.20.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -60,7 +60,7 @@
       <dependency>
         <groupId>org.testcontainers</groupId>
         <artifactId>testcontainers-bom</artifactId>
-        <version>1.17.3</version>
+        <version>1.19.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
## Purpose
Upgrade dependencies. Resolves [https://issues.folio.org/browse/MODPUBSUB-279](MODPUBSUB-279).

## Approach
_How does this change fulfill the purpose?_

#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.

## Learning
_Describe the research stage. Add links to blog posts, patterns, libraries or addons used to solve this problem._
