### PR TITLE
MODPUBSUB-283: RMB 35.1.1, folio-di-support 2.0.1, kafka-clients 3.6.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
   </modules>
 
   <properties>
-    <raml-module-builder.version>35.1.0</raml-module-builder.version>
+    <raml-module-builder.version>35.1.1</raml-module-builder.version>
     <vertx.version>4.4.6</vertx.version>
     <lombok.version>1.18.28</lombok.version>
     <wiremock.version>2.27.2</wiremock.version>
@@ -68,13 +68,13 @@
       <dependency>
         <groupId>org.folio</groupId>
         <artifactId>folio-di-support</artifactId>
-        <version>1.6.0</version>
+        <version>2.0.1</version>
       </dependency>
 
       <dependency>
         <groupId>org.apache.kafka</groupId>
         <artifactId>kafka-clients</artifactId>
-        <version>3.2.3</version>
+        <version>3.6.0</version>
       </dependency>
 
     </dependencies>


### PR DESCRIPTION
https://issues.folio.org/browse/MODPUBSUB-283

Upgrade RMB from 35.1.0 to 35.1.1 to match the Vert.x 4.4.6 version.

Upgrade folio-di-support from 1.6.0 to 2.0.1. This indirectly upgrades spring-expression from 5.3.20 to 6.0.12 fixing Allocation of Resources Without Limits or Throttling:
https://nvd.nist.gov/vuln/detail/CVE-2023-20863
https://nvd.nist.gov/vuln/detail/CVE-2023-20861

Upgrade kafka-clients from 3.2.3 to 3.6.0 fixing Deserialization of Untrusted Data:
https://nvd.nist.gov/vuln/detail/CVE-2023-25194

The kafka-clients upgrade indirectly upgrades snappy-java from 1.1.8.4 to 1.1.10.4 fixing Allocation of Resources Without Limits or Throttling, Denial of Service (DoS), Integer Overflow or Wraparound:
https://nvd.nist.gov/vuln/detail/CVE-2023-43642
https://nvd.nist.gov/vuln/detail/CVE-2023-34455
https://nvd.nist.gov/vuln/detail/CVE-2023-34453
https://nvd.nist.gov/vuln/detail/CVE-2023-34454
https://nvd.nist.gov/vuln/detail/CVE-2023-25194