### PR TITLE
MODPUBSUB-286 Fix memory leak issue

### DIFF
--- a/mod-pubsub-server/pom.xml
+++ b/mod-pubsub-server/pom.xml
@@ -113,7 +113,7 @@
     <dependency>
       <groupId>com.github.ben-manes.caffeine</groupId>
       <artifactId>caffeine</artifactId>
-      <version>3.1.1</version>
+      <version>3.1.8</version>
     </dependency>
     <dependency>
       <groupId>org.folio</groupId>

--- a/mod-pubsub-server/src/main/java/org/folio/services/cache/Cache.java
+++ b/mod-pubsub-server/src/main/java/org/folio/services/cache/Cache.java
@@ -4,12 +4,11 @@ import static org.apache.commons.collections4.IterableUtils.isEmpty;
 
 import java.util.HashSet;
 import java.util.Set;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.Executors;
 import java.util.function.Consumer;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.checkerframework.checker.index.qual.NonNegative;
 import org.folio.dao.MessagingModuleDao;
 import org.folio.rest.jaxrs.model.MessagingModule;
 import org.folio.rest.util.ExpiryAwareToken;
@@ -19,7 +18,6 @@ import org.springframework.stereotype.Component;
 
 import com.github.benmanes.caffeine.cache.AsyncLoadingCache;
 import com.github.benmanes.caffeine.cache.Caffeine;
-import com.github.benmanes.caffeine.cache.Expiry;
 import com.github.benmanes.caffeine.cache.RemovalCause;
 import com.github.benmanes.caffeine.cache.Scheduler;
 
@@ -53,6 +51,7 @@ public class Cache {
       .buildAsync(k -> new HashSet<>());
     this.subscriptions = Caffeine.newBuilder().build();
     this.tenantAccessToken = Caffeine.newBuilder()
+      .executor(Executors.newCachedThreadPool())
       .scheduler(Scheduler.systemScheduler())
       .expireAfter(new HalfMaxAgeTokenExpiryPolicy())
       .removalListener((tenant, token, cause) -> {
@@ -64,6 +63,7 @@ public class Cache {
       })
       .build();
     this.tenantRefreshToken = Caffeine.newBuilder()
+      .executor(Executors.newCachedThreadPool())
       .scheduler(Scheduler.systemScheduler())
       .expireAfter(new HalfMaxAgeTokenExpiryPolicy())
       .removalListener((tenant, token, cause) -> {


### PR DESCRIPTION
## Purpose
Performance tests of the Check In/Out workflows show that in Poppy mod-pubsub has a memory leak. Details from [PERF-721](https://issues.folio.org/browse/PERF-721):

Longevity test was conducted for CICO on pcp1 (75 users, 8 hours). During this test mod-pubsub memory consumption increased from 37% to 63%.
Class taking most of the memory - "java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue". At the end of the test it occupies 95% of bytes. There is a big number of events like java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask inside the class. Number of these events at the beginning of the test - 83K, number at the end of the test - 840K.

Resolves: [MODPUBSUB-286](https://issues.folio.org/browse/MODPUBSUB-286)

## Approach
- override custom executors for Caffeine cache;
- update Caffeine version;
