### PR TITLE
MODPUBSUB-290 Use folio-kafka-wrapper to create topics

### DIFF
--- a/mod-pubsub-server/pom.xml
+++ b/mod-pubsub-server/pom.xml
@@ -95,6 +95,16 @@
       <artifactId>kafka-clients</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.folio</groupId>
+      <artifactId>folio-kafka-wrapper</artifactId>
+      <version>3.1.1</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <version>3.14.0</version>
+    </dependency>
+    <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-web-client</artifactId>
     </dependency>

--- a/mod-pubsub-server/src/main/java/org/folio/config/ApplicationConfig.java
+++ b/mod-pubsub-server/src/main/java/org/folio/config/ApplicationConfig.java
@@ -6,7 +6,8 @@ import java.util.Map;
 import javax.annotation.PreDestroy;
 
 import org.apache.kafka.clients.admin.AdminClientConfig;
-import org.folio.kafka.KafkaConfig;
+import org.folio.kafka.PubSubKafkaConfig;
+import org.folio.kafka.services.KafkaAdminClientService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
@@ -26,11 +27,16 @@ public class ApplicationConfig {
 
   private KafkaAdminClient adminClient;
   @Bean
-  public KafkaAdminClient kafkaAdminClient(@Autowired Vertx vertx, @Autowired KafkaConfig config) {
+  public KafkaAdminClient kafkaAdminClient(@Autowired Vertx vertx, @Autowired PubSubKafkaConfig config) {
     Map<String, String> configs = new HashMap<>();
     configs.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, config.getKafkaUrl());
     adminClient = KafkaAdminClient.create(vertx, configs);
     return adminClient;
+  }
+
+  @Bean
+  public KafkaAdminClientService kafkaAdminClientService(@Autowired Vertx vertx) {
+    return new KafkaAdminClientService(vertx);
   }
 
   @PreDestroy

--- a/mod-pubsub-server/src/main/java/org/folio/kafka/PubSubKafkaConfig.java
+++ b/mod-pubsub-server/src/main/java/org/folio/kafka/PubSubKafkaConfig.java
@@ -12,7 +12,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 @Component
-public class KafkaConfig {
+public class PubSubKafkaConfig {
 
   @Value("${KAFKA_HOST}")
   private String kafkaHost;

--- a/mod-pubsub-server/src/main/java/org/folio/kafka/PubSubKafkaTopic.java
+++ b/mod-pubsub-server/src/main/java/org/folio/kafka/PubSubKafkaTopic.java
@@ -1,0 +1,6 @@
+package org.folio.kafka;
+
+import org.folio.kafka.services.KafkaTopic;
+
+public record PubSubKafkaTopic(String moduleName, String topicName) implements KafkaTopic {
+}

--- a/mod-pubsub-server/src/main/java/org/folio/services/impl/KafkaConsumerServiceImpl.java
+++ b/mod-pubsub-server/src/main/java/org/folio/services/impl/KafkaConsumerServiceImpl.java
@@ -14,7 +14,7 @@ import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.HttpStatus;
-import org.folio.kafka.KafkaConfig;
+import org.folio.kafka.PubSubKafkaConfig;
 import org.folio.kafka.PubSubConfig;
 import org.folio.okapi.common.GenericCompositeFuture;
 import org.folio.rest.jaxrs.model.AuditMessage;
@@ -53,14 +53,14 @@ public class KafkaConsumerServiceImpl implements ConsumerService {
   private static final Logger LOGGER = LogManager.getLogger();
 
   private Vertx vertx;
-  private KafkaConfig kafkaConfig;
+  private PubSubKafkaConfig kafkaConfig;
   private Cache cache;
   private AuditService auditService;
   private SecurityManager securityManager;
   private static final int RETRY_NUMBER = Integer.parseInt(MODULE_SPECIFIC_ARGS.getOrDefault("pubsub.delivery.retry.number", "5"));
 
   public KafkaConsumerServiceImpl(@Autowired Vertx vertx,
-                                  @Autowired KafkaConfig kafkaConfig,
+                                  @Autowired PubSubKafkaConfig kafkaConfig,
                                   @Autowired SecurityManager securityManager,
                                   @Autowired Cache cache) {
     this.vertx = vertx;

--- a/mod-pubsub-server/src/main/java/org/folio/services/impl/KafkaTopicServiceImpl.java
+++ b/mod-pubsub-server/src/main/java/org/folio/services/impl/KafkaTopicServiceImpl.java
@@ -1,43 +1,42 @@
 package org.folio.services.impl;
 
-import io.vertx.core.Future;
-import io.vertx.kafka.admin.KafkaAdminClient;
-import io.vertx.kafka.admin.NewTopic;
+import static io.vertx.core.Future.succeededFuture;
+
+import java.util.List;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.folio.kafka.KafkaConfig;
-import org.folio.kafka.PubSubConfig;
+import org.folio.kafka.PubSubKafkaTopic;
+import org.folio.kafka.services.KafkaAdminClientService;
 import org.folio.services.KafkaTopicService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import java.util.List;
-import java.util.stream.Collectors;
+import io.vertx.core.Future;
 
 @Component
 public class KafkaTopicServiceImpl implements KafkaTopicService {
 
   private static final Logger LOGGER = LogManager.getLogger();
 
-  private KafkaAdminClient kafkaAdminClient;
-  private KafkaConfig kafkaConfig;
+  private final KafkaAdminClientService kafkaAdminClientService;
 
-  public KafkaTopicServiceImpl(@Autowired KafkaAdminClient kafkaAdminClient, @Autowired KafkaConfig kafkaConfig) {
-    this.kafkaAdminClient = kafkaAdminClient;
-    this.kafkaConfig = kafkaConfig;
+  public KafkaTopicServiceImpl(@Autowired KafkaAdminClientService kafkaAdminClientService) {
+    this.kafkaAdminClientService = kafkaAdminClientService;
   }
 
   @Override
   public Future<Void> createTopics(List<String> eventTypes, String tenantId) {
-    List<NewTopic> topics = eventTypes.stream()
-      .map(eventType -> new NewTopic(new PubSubConfig(kafkaConfig.getEnvId(), tenantId, eventType).getTopicName(), kafkaConfig.getNumberOfPartitions(), (short) kafkaConfig.getReplicationFactor()))
-      .collect(Collectors.toList());
-    return kafkaAdminClient.createTopics(topics)
+    PubSubKafkaTopic[] topics = eventTypes.stream()
+      .map(eventType -> new PubSubKafkaTopic("mod-pubsub", eventType))
+      .toArray(PubSubKafkaTopic[]::new);
+
+    return succeededFuture()
+      .compose(r -> kafkaAdminClientService.createKafkaTopics(topics, tenantId))
       .onSuccess(r -> LOGGER.info("Created topics: [{}]", StringUtils.join(eventTypes, ",")))
       .onFailure(e -> LOGGER.error("Some of the topics [{}] were not created. Cause: {}",
         StringUtils.join(eventTypes, ","), e.getMessage(), e))
-      .recover(e -> Future.succeededFuture());
+      .recover(e -> succeededFuture());
   }
 }

--- a/mod-pubsub-server/src/main/java/org/folio/services/impl/StartupServiceImpl.java
+++ b/mod-pubsub-server/src/main/java/org/folio/services/impl/StartupServiceImpl.java
@@ -3,7 +3,7 @@ package org.folio.services.impl;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import org.folio.dao.MessagingModuleDao;
-import org.folio.kafka.KafkaConfig;
+import org.folio.kafka.PubSubKafkaConfig;
 import org.folio.rest.util.MessagingModuleFilter;
 import org.folio.rest.util.OkapiConnectionParams;
 import org.folio.services.ConsumerService;
@@ -21,13 +21,13 @@ import static org.folio.rest.jaxrs.model.MessagingModule.ModuleRole.SUBSCRIBER;
 public class StartupServiceImpl implements StartupService {
 
   private Vertx vertx;
-  private KafkaConfig kafkaConfig;
+  private PubSubKafkaConfig kafkaConfig;
   private MessagingModuleDao messagingModuleDao;
   private ConsumerService consumerService;
   private KafkaTopicService kafkaTopicService;
 
   public StartupServiceImpl(@Autowired Vertx vertx,
-                            @Autowired KafkaConfig kafkaConfig,
+                            @Autowired PubSubKafkaConfig kafkaConfig,
                             @Autowired MessagingModuleDao messagingModuleDao,
                             @Autowired ConsumerService consumerService,
                             @Autowired KafkaTopicService kafkaTopicService) {

--- a/mod-pubsub-server/src/main/java/org/folio/services/publish/PublishingServiceImpl.java
+++ b/mod-pubsub-server/src/main/java/org/folio/services/publish/PublishingServiceImpl.java
@@ -8,7 +8,7 @@ import io.vertx.kafka.client.producer.KafkaProducer;
 import io.vertx.kafka.client.producer.impl.KafkaProducerRecordImpl;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.folio.kafka.KafkaConfig;
+import org.folio.kafka.PubSubKafkaConfig;
 import org.folio.kafka.PubSubConfig;
 import org.folio.rest.jaxrs.model.AuditMessage;
 import org.folio.rest.jaxrs.model.Event;
@@ -27,13 +27,13 @@ public class PublishingServiceImpl implements PublishingService {
   private static final int THREAD_POOL_SIZE =
     Integer.parseInt(MODULE_SPECIFIC_ARGS.getOrDefault("event.publishing.thread.pool.size", "20"));
 
-  private KafkaConfig kafkaConfig;
+  private PubSubKafkaConfig kafkaConfig;
   private WorkerExecutor executor;
   private AuditService auditService;
   private Vertx vertx;
 
   public PublishingServiceImpl(@Autowired Vertx vertx,
-                               @Autowired KafkaConfig kafkaConfig) {
+                               @Autowired PubSubKafkaConfig kafkaConfig) {
     this.kafkaConfig = kafkaConfig;
     this.auditService = AuditService.createProxy(vertx);
     this.vertx = vertx;

--- a/mod-pubsub-server/src/test/java/org/folio/kafka/PubSubKafkaConfigTest.java
+++ b/mod-pubsub-server/src/test/java/org/folio/kafka/PubSubKafkaConfigTest.java
@@ -6,11 +6,11 @@ import org.junit.Assert;
 import org.junit.Test;
 
 
-public class KafkaConfigTest {
+public class PubSubKafkaConfigTest {
 
   @Test
   public void shouldReturnProducerProperties() {
-    Map<String, String> producerProps = new KafkaConfig().getProducerProps();
+    Map<String, String> producerProps = new PubSubKafkaConfig().getProducerProps();
 
     Assert.assertEquals("PLAINTEXT", producerProps.get("security.protocol"));
     Assert.assertEquals("TLSv1.2", producerProps.get("ssl.protocol"));
@@ -21,7 +21,7 @@ public class KafkaConfigTest {
 
   @Test
   public void shouldReturnConsumerProperties() {
-    Map<String, String> consumerProps = new KafkaConfig().getConsumerProps();
+    Map<String, String> consumerProps = new PubSubKafkaConfig().getConsumerProps();
 
     Assert.assertEquals("PLAINTEXT", consumerProps.get("security.protocol"));
     Assert.assertEquals("TLSv1.2", consumerProps.get("ssl.protocol"));

--- a/mod-pubsub-server/src/test/java/org/folio/services/impl/ConsumerServiceUnitTest.java
+++ b/mod-pubsub-server/src/test/java/org/folio/services/impl/ConsumerServiceUnitTest.java
@@ -22,7 +22,7 @@ import java.util.UUID;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.folio.config.user.SystemUserConfig;
-import org.folio.kafka.KafkaConfig;
+import org.folio.kafka.PubSubKafkaConfig;
 import org.folio.rest.jaxrs.model.Event;
 import org.folio.rest.jaxrs.model.EventMetadata;
 import org.folio.rest.jaxrs.model.MessagingModule;
@@ -71,7 +71,7 @@ public class ConsumerServiceUnitTest {
 
   private Vertx vertx = Vertx.vertx();
   @Mock
-  private KafkaConfig kafkaConfig;
+  private PubSubKafkaConfig kafkaConfig;
   @Mock
   private Cache cache;
   @Mock


### PR DESCRIPTION
## Purpose
Add support for SSL-enabled Kafka instances.

## Approach
Use [folio-kafka-wrapper](https://github.com/folio-org/folio-kafka-wrapper) to create topics. This ensures that Kafka admin client is created with SSL-related properties.

#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.

## Learning
_Describe the research stage. Add links to blog posts, patterns, libraries or addons used to solve this problem._
