### PR TITLE
EUREKA-225 Add system user to ModuleDescriptor.json

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -305,7 +305,7 @@
   ],
   "metadata": {
     "user": {
-      "type": "module",
+      "type": "system",
       "permissions": [
         "pubsub.events.post"
       ]

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -303,6 +303,14 @@
       ]
     }
   ],
+  "metadata": {
+    "user": {
+      "type": "module",
+      "permissions": [
+        "pubsub.events.post"
+      ]
+    }
+  },
   "launchDescriptor": {
     "dockerImage": "${artifactId}:${version}",
     "dockerArgs": {


### PR DESCRIPTION
## Purpose

Adds a system user description in the module descriptor (see [EUREKA-225](https://folio-org.atlassian.net/browse/EUREKA-225))

## Approach

- Adds a system user description in the module descriptor to the metadata field

#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.

## Learning
_Describe the research stage. Add links to blog posts, patterns, libraries or addons used to solve this problem._
