### PR TITLE
MODPUBSUB-309: kafka-clients 3.9.0, folio-di-support 2.2.0, vertx 4.5.11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
   <properties>
     <raml-module-builder.version>35.3.0</raml-module-builder.version>
-    <vertx.version>4.5.10</vertx.version>
+    <vertx.version>4.5.11</vertx.version>
     <lombok.version>1.18.28</lombok.version>
     <wiremock.version>2.27.2</wiremock.version>
     <junit.version>4.13.2</junit.version>
@@ -71,13 +71,13 @@
       <dependency>
         <groupId>org.folio</groupId>
         <artifactId>folio-di-support</artifactId>
-        <version>2.1.0</version>
+        <version>2.2.0</version>
       </dependency>
 
       <dependency>
         <groupId>org.apache.kafka</groupId>
         <artifactId>kafka-clients</artifactId>
-        <version>3.6.0</version>
+        <version>3.9.0</version>
       </dependency>
 
     </dependencies>


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/MODPUBSUB-309

## Purpose
Fix security vulnerabilities.

## Approach
Upgrade kafka-client from 3.6.0 to 3.9.0 fixing

* https://www.cve.org/CVERecord?id=CVE-2023-43642 Allocation of Resources Without Limits or Throttling
* https://www.cve.org/CVERecord?id=CVE-2023-34455 Denial of Service (DoS)
* https://www.cve.org/CVERecord?id=CVE-2023-34454 compress Integer Overflow or Wraparound
* https://www.cve.org/CVERecord?id=CVE-2023-34453 shuffle Integer Overflow or Wraparound
* https://www.cve.org/CVERecord?id=CVE-2024-56128 SCRAM SASL_PLAINTEXT Incorrect Implementation of Authentication Algorithm
* https://www.cve.org/CVERecord?id=CVE-2024-31141  ConfigProviders Files or Directories Accessible to External Parties

Upgrade folio-di-support from 2.1.0 to 2.2.0. This indirectly upgrades spring-context from 6.0.12 to 6.1.14 fixing

* https://www.cve.org/CVERecord?id=CVE-2024-38820 disallowedFields/Locale – Improper Handling of Case Sensitivity

Upgrade Vert.x from 4.5.10 to 4.5.11. This indirectly upgrades Netty from 4.1.107.Final to 4.1.115.Final fixing

* https://www.cve.org/CVERecord?id=CVE-2024-29025 HttpPostRequestDecoder Allocation of Resources Without Limits or Throttling