### PR TITLE
MODPUBSUB-315: Add missing event hanlder permissions for Okapi

### DIFF
--- a/mod-pubsub-server/src/main/resources/permissions/pubsub-user-permissions.csv
+++ b/mod-pubsub-server/src/main/resources/permissions/pubsub-user-permissions.csv
@@ -1,3 +1,13 @@
 pubsub.events.post
 audit.pub-sub-handlers.log-record-event.post
 remote-storage.pub-sub-handlers.log-record-event.post
+circulation.handlers.loan-related-fee-fine-closed.post
+circulation.handlers.fee-fine-balance-changed.post
+patron-blocks.handlers.fee-fine-balance-changed.post
+patron-blocks.handlers.item-checked-out.post
+patron-blocks.handlers.item-checked-in.post
+patron-blocks.handlers.item-declared-lost.post
+patron-blocks.handlers.item-aged-to-lost.post
+patron-blocks.handlers.item-claimed-returned.post
+patron-blocks.handlers.loan-due-date-changed.post
+patron-blocks.handlers.loan-closed.post


### PR DESCRIPTION
## Purpose
Add missing event handler permissions for mod-circulation and mod-patron-blocks
[MODPUBSUB-315](https://folio-org.atlassian.net/browse/MODPUBSUB-315)

## Approach
_How does this change fulfill the purpose?_

#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.

## Learning
_Describe the research stage. Add links to blog posts, patterns, libraries or addons used to solve this problem._
