### PR TITLE
MODPUBSUB-315: Declare permissions for mod-patron-blocks event handlers

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -316,6 +316,46 @@
       "description": "Fee/fine balance changed"
     },
     {
+      "permissionName": "patron-blocks.handlers.fee-fine-balance-changed.post",
+      "displayName": "Patron blocks - post fee fine balance changed event",
+      "description": "Post fee fine balance changed event"
+    },
+    {
+      "permissionName": "patron-blocks.handlers.item-checked-out.post",
+      "displayName": "Patron blocks - post item checked out event",
+      "description": "Post item checked out event"
+    },
+    {
+      "permissionName": "patron-blocks.handlers.item-checked-in.post",
+      "displayName": "Patron blocks - post item checked in event",
+      "description": "Post item checked in event"
+    },
+    {
+      "permissionName": "patron-blocks.handlers.item-declared-lost.post",
+      "displayName": "Patron blocks - post item declared lost event",
+      "description": "Post item declared lost event"
+    },
+    {
+      "permissionName": "patron-blocks.handlers.item-aged-to-lost.post",
+      "displayName": "Patron blocks - post item aged to lost event",
+      "description": "Post item aged to lost event"
+    },
+    {
+      "permissionName": "patron-blocks.handlers.item-claimed-returned.post",
+      "displayName": "Patron blocks - post item claimed returned event",
+      "description": "Post item claimed returned event"
+    },
+    {
+      "permissionName": "patron-blocks.handlers.loan-due-date-changed.post",
+      "displayName": "Patron blocks - post loan due date changed event",
+      "description": "Post loan due date changed event"
+    },
+    {
+      "permissionName": "patron-blocks.handlers.loan-closed.post",
+      "displayName": "Patron blocks - post loan closed event",
+      "description": "Post loan closed event"
+    },
+    {
       "permissionName": "pubsub.events.post",
       "displayName": "PubSub - post event.",
       "description": "Post all events.",


### PR DESCRIPTION
## Purpose
Declare permissions for mod-patron-blocks event handlers.
[MODPUBSUB-315](https://folio-org.atlassian.net/browse/MODPUBSUB-315)

## Approach
_How does this change fulfill the purpose?_

#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.

## Learning
_Describe the research stage. Add links to blog posts, patterns, libraries or addons used to solve this problem._
