### PR TITLE
Upgrade confluentinc/cp-kafka:7.3.1 to apache/kafka-native:3.8.0

### DIFF
--- a/mod-pubsub-server/src/test/java/org/folio/rest/impl/AbstractRestTest.java
+++ b/mod-pubsub-server/src/test/java/org/folio/rest/impl/AbstractRestTest.java
@@ -70,8 +70,9 @@ public abstract class AbstractRestTest {
   static RequestSpecification spec;
   private static String useExternalDatabase;
   protected static Vertx vertx;
-  private static final KafkaContainer kafkaContainer = new KafkaContainer(
-    DockerImageName.parse("apache/kafka-native:3.8.0"));
+  private static final KafkaContainer kafkaContainer =
+      new KafkaContainer(DockerImageName.parse("apache/kafka-native:3.8.0"))
+      .withStartupAttempts(3);
 
   @BeforeClass
   public static void setUpClass(final TestContext context) throws Exception {

--- a/mod-pubsub-server/src/test/java/org/folio/rest/impl/AbstractRestTest.java
+++ b/mod-pubsub-server/src/test/java/org/folio/rest/impl/AbstractRestTest.java
@@ -22,7 +22,7 @@ import org.folio.rest.tools.utils.NetworkUtils;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.testcontainers.containers.KafkaContainer;
+import org.testcontainers.kafka.KafkaContainer;
 import org.testcontainers.utility.DockerImageName;
 
 import io.restassured.builder.RequestSpecBuilder;
@@ -71,7 +71,7 @@ public abstract class AbstractRestTest {
   private static String useExternalDatabase;
   protected static Vertx vertx;
   private static final KafkaContainer kafkaContainer = new KafkaContainer(
-    DockerImageName.parse("confluentinc/cp-kafka:7.3.1"));
+    DockerImageName.parse("apache/kafka-native:3.8.0"));
 
   @BeforeClass
   public static void setUpClass(final TestContext context) throws Exception {


### PR DESCRIPTION
## Purpose
confluentinc/cp-kafka:7.3.1 is deprecated.

## Approach
https://folio-org.atlassian.net/wiki/spaces/TC/pages/730891059/Trillium#Trillium-Infrastructure requires Kafka 3.8.0.