### PR TITLE
MODPUBSUB-325: Fix CQL when calling GET /users?query=username==

### DIFF
--- a/mod-pubsub-server/src/main/java/org/folio/services/impl/SecurityManagerImpl.java
+++ b/mod-pubsub-server/src/main/java/org/folio/services/impl/SecurityManagerImpl.java
@@ -28,6 +28,7 @@ import org.folio.rest.util.OkapiConnectionParams;
 import org.folio.rest.util.RestUtil;
 import org.folio.services.SecurityManager;
 import org.folio.services.cache.Cache;
+import org.folio.util.StringUtil;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -196,7 +197,7 @@ public class SecurityManagerImpl implements SecurityManager {
   }
 
   private Future<User> existsPubSubUser(OkapiConnectionParams params) {
-    String query = "?query=username=" + systemUserConfig.getName();
+    String query = "?query=username==" + StringUtil.cqlEncode(systemUserConfig.getName());
     return doRequest(params, USERS_URL + query, HttpMethod.GET, null)
       .compose(response -> {
         Promise<User> promise = Promise.promise();

--- a/mod-pubsub-server/src/main/java/org/folio/services/impl/SecurityManagerImpl.java
+++ b/mod-pubsub-server/src/main/java/org/folio/services/impl/SecurityManagerImpl.java
@@ -28,6 +28,7 @@ import org.folio.rest.util.OkapiConnectionParams;
 import org.folio.rest.util.RestUtil;
 import org.folio.services.SecurityManager;
 import org.folio.services.cache.Cache;
+import org.folio.util.PercentCodec;
 import org.folio.util.StringUtil;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -197,8 +198,9 @@ public class SecurityManagerImpl implements SecurityManager {
   }
 
   private Future<User> existsPubSubUser(OkapiConnectionParams params) {
-    String query = "?query=username==" + StringUtil.cqlEncode(systemUserConfig.getName());
-    return doRequest(params, USERS_URL + query, HttpMethod.GET, null)
+    var cql = "username==" + StringUtil.cqlEncode(systemUserConfig.getName());
+    var url = USERS_URL + "?query=" + PercentCodec.encode(cql);
+    return doRequest(params, url, HttpMethod.GET, null)
       .compose(response -> {
         Promise<User> promise = Promise.promise();
         if (response.getCode() == HttpStatus.HTTP_OK.toInt()) {

--- a/mod-pubsub-server/src/test/java/org/folio/rest/impl/ModTenantApiTest.java
+++ b/mod-pubsub-server/src/test/java/org/folio/rest/impl/ModTenantApiTest.java
@@ -34,7 +34,8 @@ public class ModTenantApiTest extends AbstractRestTest {
   private static final String MODULE_TO_VERSION = "mod-pubsub-1.0.0";
   private static final String TENANT_URL = "/_/tenant";
   private static final String USERS_URL = "/users";
-  private static final String GET_PUBSUB_USER_URL = USERS_URL + "?query=username==\"" + SYSTEM_USER_NAME + "\"";
+  private static final String GET_PUBSUB_USER_URL =
+      USERS_URL + "?query=username%3D%3D%22" + SYSTEM_USER_NAME + "%22";
 
   @ClassRule
   public static WireMockRule wireMockRule = new WireMockRule(

--- a/mod-pubsub-server/src/test/java/org/folio/rest/impl/ModTenantApiTest.java
+++ b/mod-pubsub-server/src/test/java/org/folio/rest/impl/ModTenantApiTest.java
@@ -34,8 +34,7 @@ public class ModTenantApiTest extends AbstractRestTest {
   private static final String MODULE_TO_VERSION = "mod-pubsub-1.0.0";
   private static final String TENANT_URL = "/_/tenant";
   private static final String USERS_URL = "/users";
-  private static final String GET_PUBSUB_USER_URL = USERS_URL + "?query=username=" + SYSTEM_USER_NAME;
-  private static final String LOGIN_URL = "/authn/login";
+  private static final String GET_PUBSUB_USER_URL = USERS_URL + "?query=username==\"" + SYSTEM_USER_NAME + "\"";
 
   @ClassRule
   public static WireMockRule wireMockRule = new WireMockRule(

--- a/mod-pubsub-server/src/test/java/org/folio/rest/impl/PubSubIT.java
+++ b/mod-pubsub-server/src/test/java/org/folio/rest/impl/PubSubIT.java
@@ -78,7 +78,7 @@ public class PubSubIT {
   public static void beforeClass() {
     okapi.start();
     Testcontainers.exposeHostPorts(okapi.port());
-    okapi.stubFor(get("/users?query=username=pub-sub").willReturn(okJson("{\"users\":[]}")));
+    okapi.stubFor(get("/users?query=username==\"pub-sub\"").willReturn(okJson("{\"users\":[]}")));
     okapi.stubFor(post("/users").willReturn(created()));
     okapi.stubFor(post("/authn/credentials").willReturn(created()));
     okapi.stubFor(get(urlPathMatching("/perms/users/.*")).willReturn(notFound()));

--- a/mod-pubsub-server/src/test/java/org/folio/rest/impl/PubSubIT.java
+++ b/mod-pubsub-server/src/test/java/org/folio/rest/impl/PubSubIT.java
@@ -78,7 +78,7 @@ public class PubSubIT {
   public static void beforeClass() {
     okapi.start();
     Testcontainers.exposeHostPorts(okapi.port());
-    okapi.stubFor(get("/users?query=username==\"pub-sub\"").willReturn(okJson("{\"users\":[]}")));
+    okapi.stubFor(get("/users?query=username%3D%3D%22pub-sub%22").willReturn(okJson("{\"users\":[]}")));
     okapi.stubFor(post("/users").willReturn(created()));
     okapi.stubFor(post("/authn/credentials").willReturn(created()));
     okapi.stubFor(get(urlPathMatching("/perms/users/.*")).willReturn(notFound()));

--- a/mod-pubsub-server/src/test/java/org/folio/rest/impl/PublishTest.java
+++ b/mod-pubsub-server/src/test/java/org/folio/rest/impl/PublishTest.java
@@ -1,6 +1,5 @@
 package org.folio.rest.impl;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.any;
 import static com.github.tomakehurst.wiremock.client.WireMock.created;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
@@ -46,8 +45,6 @@ public class PublishTest extends AbstractRestTest {
   private static final String PUBLISH_PATH = "/pubsub/publish";
   private static final String CALLBACK_ADDRESS = "/call-me-maybe";
   private static final String LOGIN_URL = "/authn/login-with-expiry";
-  private static final String USERS_URL = "/users";
-  private static final String GET_PUBSUB_USER_URL = USERS_URL + "?query=username==\"" + SYSTEM_USER_NAME + "\"";
   long TOKEN_MAX_AGE = 600;
   long TOKEN_MAX_AGE_LONG = 604800;
   String ACCESS_TOKEN = UUID.randomUUID().toString();
@@ -191,21 +188,6 @@ public class PublishTest extends AbstractRestTest {
   @Before
   public void setUp(){
     wireMockRule.stubFor(any(urlEqualTo(CALLBACK_ADDRESS)));
-    wireMockRule.stubFor(post(urlEqualTo(GET_PUBSUB_USER_URL))
-      .willReturn(aResponse()
-        .withBody("""
-          {
-              "users": [
-                  {
-                      "username": "test-pubsub-username",
-                      "id": "5a05e962-0502-5f78-a1fb-c47ba902298b",
-                      "active": true,
-                      "patronGroup": "3684a786-6671-4268-8ed0-9db82ebca60b"
-                  }
-              ],
-              "totalRecords": 1
-          }
-          """)));
     stubFor(post(LOGIN_URL)
       .willReturn(created()
         .withHeader("Set-Cookie", ACCESS_TOKEN_COOKIE)

--- a/mod-pubsub-server/src/test/java/org/folio/rest/impl/PublishTest.java
+++ b/mod-pubsub-server/src/test/java/org/folio/rest/impl/PublishTest.java
@@ -47,7 +47,7 @@ public class PublishTest extends AbstractRestTest {
   private static final String CALLBACK_ADDRESS = "/call-me-maybe";
   private static final String LOGIN_URL = "/authn/login-with-expiry";
   private static final String USERS_URL = "/users";
-  private static final String GET_PUBSUB_USER_URL = USERS_URL + "?query=username=" + SYSTEM_USER_NAME;
+  private static final String GET_PUBSUB_USER_URL = USERS_URL + "?query=username==\"" + SYSTEM_USER_NAME + "\"";
   long TOKEN_MAX_AGE = 600;
   long TOKEN_MAX_AGE_LONG = 604800;
   String ACCESS_TOKEN = UUID.randomUUID().toString();

--- a/mod-pubsub-server/src/test/java/org/folio/services/impl/SecurityManagerTest.java
+++ b/mod-pubsub-server/src/test/java/org/folio/services/impl/SecurityManagerTest.java
@@ -74,7 +74,7 @@ public class SecurityManagerTest {
 
   private static final String LOGIN_URL = "/authn/login-with-expiry";
   private static final String USERS_URL = "/users";
-  private static final String USERS_URL_WITH_QUERY = "/users?query=username=" + SYSTEM_USER_NAME;
+  private static final String USERS_URL_WITH_QUERY = "/users?query=username==\"" + SYSTEM_USER_NAME + "\"";
   private static final String CREDENTIALS_URL = "/authn/credentials";
   private static final String PERMISSIONS_URL = "/perms/users";
   private static final String TENANT = "diku";

--- a/mod-pubsub-server/src/test/java/org/folio/services/impl/SecurityManagerTest.java
+++ b/mod-pubsub-server/src/test/java/org/folio/services/impl/SecurityManagerTest.java
@@ -74,7 +74,8 @@ public class SecurityManagerTest {
 
   private static final String LOGIN_URL = "/authn/login-with-expiry";
   private static final String USERS_URL = "/users";
-  private static final String USERS_URL_WITH_QUERY = "/users?query=username==\"" + SYSTEM_USER_NAME + "\"";
+  private static final String USERS_URL_WITH_QUERY =
+      "/users?query=username%3D%3D%22" + SYSTEM_USER_NAME + "%22";
   private static final String CREDENTIALS_URL = "/authn/credentials";
   private static final String PERMISSIONS_URL = "/perms/users";
   private static final String TENANT = "diku";


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/MODPUBSUB-325

## Purpose
Fix wrong CQL.

## Approach
Use `==` exact match operator, not `=` word match operator.

Use `StringUtil.cqlEncode` to put username into quotes and mask special CQL characters.

## Learning
Use `==` for exact match CQL queries.

Use `StringUtil.cqlEncode` to avoid CQL injection.