### PR TITLE
MODPUBSUB-326: Always close producer; more logging; remove executor

### DIFF
--- a/mod-pubsub-server/pom.xml
+++ b/mod-pubsub-server/pom.xml
@@ -43,9 +43,13 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>${junit.version}</version>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-junit5</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/mod-pubsub-server/src/main/java/org/folio/services/publish/PublishingServiceImpl.java
+++ b/mod-pubsub-server/src/main/java/org/folio/services/publish/PublishingServiceImpl.java
@@ -1,82 +1,70 @@
 package org.folio.services.publish;
 
-import static org.folio.rest.RestVerticle.MODULE_SPECIFIC_ARGS;
+import static org.folio.rest.jaxrs.model.AuditMessage.State.PUBLISHED;
+import static org.folio.rest.jaxrs.model.AuditMessage.State.REJECTED;
 import static org.folio.services.util.AuditUtil.constructJsonAuditMessage;
 
-import java.util.Objects;
-import io.vertx.core.Future;
-import io.vertx.core.Vertx;
-import io.vertx.core.WorkerExecutor;
-import io.vertx.core.json.Json;
-import io.vertx.kafka.client.producer.KafkaProducer;
-import io.vertx.kafka.client.producer.impl.KafkaProducerRecordImpl;
-
-import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.folio.kafka.PubSubKafkaConfig;
 import org.folio.kafka.PubSubConfig;
-import org.folio.rest.jaxrs.model.AuditMessage;
+import org.folio.kafka.PubSubKafkaConfig;
 import org.folio.rest.jaxrs.model.Event;
 import org.folio.services.audit.AuditService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.Json;
+import io.vertx.kafka.client.producer.KafkaProducer;
+import io.vertx.kafka.client.producer.KafkaProducerRecord;
+import io.vertx.kafka.client.producer.impl.KafkaProducerRecordImpl;
 
 @Component
 public class PublishingServiceImpl implements PublishingService {
 
   private static final Logger LOGGER = LogManager.getLogger();
 
-  private static final int THREAD_POOL_SIZE =
-    Integer.parseInt(MODULE_SPECIFIC_ARGS.getOrDefault("event.publishing.thread.pool.size", "20"));
-
-  private PubSubKafkaConfig kafkaConfig;
-  private WorkerExecutor executor;
-  private AuditService auditService;
-  private Vertx vertx;
+  private final PubSubKafkaConfig kafkaConfig;
+  private final AuditService auditService;
+  private final Vertx vertx;
 
   public PublishingServiceImpl(@Autowired Vertx vertx,
                                @Autowired PubSubKafkaConfig kafkaConfig) {
     this.kafkaConfig = kafkaConfig;
     this.auditService = AuditService.createProxy(vertx);
     this.vertx = vertx;
-    this.executor = vertx.createSharedWorkerExecutor("event-publishing-thread-pool", THREAD_POOL_SIZE);
   }
 
   @Override
   public Future<Void> sendEvent(Event event, String tenantId) {
     PubSubConfig config = new PubSubConfig(kafkaConfig.getEnvId(), tenantId, event.getEventType());
-    return executor.executeBlocking(promise -> {
-        try {
-          KafkaProducer<String, String> sharedProducer = KafkaProducer.createShared(vertx,
-            config.getTopicName() + "_Producer", kafkaConfig.getProducerProps());
-
-          sharedProducer.write(new KafkaProducerRecordImpl<>(config.getTopicName(), Json.encode(event)), done -> {
-            if (done.succeeded()) {
-              LOGGER.info("Sent {} event with id '{}' to topic {}", event.getEventType(), event.getId(), config.getTopicName());
-              auditService.saveAuditMessage(constructJsonAuditMessage(event, tenantId, AuditMessage.State.PUBLISHED));
-              promise.complete();
-            } else {
-              logRejected("Event was not sent", done.cause(), config, event, tenantId);
-              promise.fail(done.cause());
-            }
-            sharedProducer.close();
-          });
-        } catch (Exception e) {
-          logRejected("Error publishing event", e, config, event, tenantId);
-          promise.fail(e);
-        }
-      });
+    KafkaProducerRecord<String, String> kafkaProducerRecord =
+        new KafkaProducerRecordImpl<>(config.getTopicName(), Json.encode(event));
+    return sendEvent(kafkaProducerRecord, config)
+        .onSuccess(x -> {
+          LOGGER.info("Sent {} event with id '{}' to topic {}",
+              event.getEventType(), event.getId(), config.getTopicName());
+          auditService.saveAuditMessage(constructJsonAuditMessage(event, tenantId, PUBLISHED));
+        })
+        .onFailure(e -> {
+          var payload = event.getEventPayload();
+          var errorMessage = event.getEventType() + " event to topic " + config.getTopicName() +
+              " was not sent. Payload size is " + (payload == null ? 0 : payload.length()) +
+              ". " + e.getMessage();
+          LOGGER.error("{}", errorMessage, e);
+          auditService.saveAuditMessage(constructJsonAuditMessage(event, tenantId, REJECTED, errorMessage));
+        });
   }
 
-  private void logRejected(String errorDescription, Throwable e, PubSubConfig config, Event event, String tenantId) {
-    var payload = event.getEventPayload();
-    var errorMessage = errorDescription + ". "
-        + event.getEventType() + " event to topic " + config.getTopicName() + " was not sent."
-        + " Payload size is " + (payload == null ? 0 : payload.length()) + ". "
-        + e.getMessage();
-    LOGGER.error("{}", errorMessage, e);
-    auditService.saveAuditMessage(
-        constructJsonAuditMessage(event, tenantId, AuditMessage.State.REJECTED, errorMessage));
+  private Future<Void> sendEvent(KafkaProducerRecord<String, String> event, PubSubConfig config) {
+    try {
+      KafkaProducer<String, String> sharedProducer = KafkaProducer.createShared(
+          vertx, config.getTopicName() + "_Producer", kafkaConfig.getProducerProps());
+      return sharedProducer.write(event)
+          .eventually(() -> sharedProducer.close());
+    } catch (Exception e) {
+      return Future.failedFuture(e);
+    }
   }
 }

--- a/mod-pubsub-server/src/test/java/org/folio/services/publish/PublishingServiceImplTest.java
+++ b/mod-pubsub-server/src/test/java/org/folio/services/publish/PublishingServiceImplTest.java
@@ -1,0 +1,32 @@
+package org.folio.services.publish;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.mock;
+
+import org.apache.kafka.common.config.ConfigException;
+import org.folio.kafka.PubSubKafkaConfig;
+import org.folio.rest.jaxrs.model.Event;
+import org.folio.rest.jaxrs.model.EventMetadata;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import io.vertx.core.Vertx;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+
+@ExtendWith(VertxExtension.class)
+class PublishingServiceImplTest {
+  @Test
+  void producerConfigException(Vertx vertx, VertxTestContext vtc) {
+    var publishingServiceImpl = new PublishingServiceImpl(vertx, mock(PubSubKafkaConfig.class));
+    var event = new Event().withEventType("foo")
+        .withEventMetadata(new EventMetadata().withCorrelationId("id"));
+    publishingServiceImpl.sendEvent(event, null)
+    .onComplete(vtc.failing(e -> {
+      assertThat(e, is(instanceOf(ConfigException.class)));
+      vtc.completeNow();
+    }));
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,14 @@
       </dependency>
 
       <dependency>
+        <groupId>org.junit</groupId>
+        <artifactId>junit-bom</artifactId>
+        <version>5.13.0</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+
+      <dependency>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-bom</artifactId>
         <version>4.7.0</version>


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/MODPUBSUB-326

Always close the KafkaProducer. The existing code doesn't close the producer in the catch clause. A dedicated method ensures that close gets always called.

On failure expand logging and audit message to include event type, topic name and payload size.

Remove WorkerExecutor, it is useless because KafkaProducer#write already uses a WorkerExecutor:
https://github.com/vert-x3/vertx-kafka-client/blob/4.5.0/src/main/java/io/vertx/kafka/client/producer/impl/KafkaWriteStreamImpl.java#L77